### PR TITLE
Converts most legacy commands to slash commands

### DIFF
--- a/command.js
+++ b/command.js
@@ -1,4 +1,5 @@
 export default class Command {
+	register(client, name) {}
 	async execute(interaction) {}
 	describe(interaction, name) {}
 }

--- a/commands/about.js
+++ b/commands/about.js
@@ -1,10 +1,13 @@
 import Command from "../command.js";
 export default class AboutCommand extends Command {
+	register(client, name) {
+		const description = "Tells you where I come from";
+		return {name, description};
+	}
 	async execute(interaction) {
 		await interaction.reply("I am *Shicka*, a bot made by *PolariTOON*, and I am open source!\nMy code is available there:\nhttps://github.com/SuperBearAdventure/shicka");
 	}
 	describe(interaction, name) {
-		const description = `Type \`/${name}\` to know where I come from`;
-		return {name, description};
+		return `Type \`/${name}\` to know where I come from`;
 	}
 }

--- a/commands/about.js
+++ b/commands/about.js
@@ -1,9 +1,10 @@
 import Command from "../command.js";
 export default class AboutCommand extends Command {
-	async execute(message, parameters) {
-		await message.reply("I am *Shicka*, a bot made by *PolariTOON*, and I am open source!\nMy code is available there:\nhttps://github.com/SuperBearAdventure/shicka");
+	async execute(interaction) {
+		await interaction.reply("I am *Shicka*, a bot made by *PolariTOON*, and I am open source!\nMy code is available there:\nhttps://github.com/SuperBearAdventure/shicka");
 	}
-	async describe(message, command) {
-		return `Type \`${command}\` to know where I come from`;
+	describe(interaction, name) {
+		const description = `Type \`/${name}\` to know where I come from`;
+		return {name, description};
 	}
 }

--- a/commands/count.js
+++ b/commands/count.js
@@ -2,13 +2,16 @@ import discord from "discord.js";
 import Command from "../command.js";
 const {Util} = discord;
 export default class CountCommand extends Command {
+	register(client, name) {
+		const description = "Tells you what is the number of members on the server";
+		return {name, description};
+	}
 	async execute(interaction) {
 		const {guild} = interaction;
 		const {memberCount, name} = guild;
 		await interaction.reply(`There are ${Util.escapeMarkdown(`${memberCount}`)} members on the official *${Util.escapeMarkdown(name)}* *Discord* server!`);
 	}
 	describe(interaction, name) {
-		const description = `Type \`/${name}\` to know the number of members on the server`;
-		return {name, description};
+		return `Type \`/${name}\` to know what is the number of members on the server`;
 	}
 }

--- a/commands/count.js
+++ b/commands/count.js
@@ -1,10 +1,14 @@
+import discord from "discord.js";
 import Command from "../command.js";
+const {Util} = discord;
 export default class CountCommand extends Command {
-	async execute(message, parameters) {
-		const {memberCount} = message.guild;
-		await message.reply(`There are ${memberCount} members on the official *Super Bear Adventure* *Discord* server!`);
+	async execute(interaction) {
+		const {guild} = interaction;
+		const {memberCount, name} = guild;
+		await interaction.reply(`There are ${Util.escapeMarkdown(`${memberCount}`)} members on the official *${Util.escapeMarkdown(name)}* *Discord* server!`);
 	}
-	async describe(message, command) {
-		return `Type \`${command}\` to know the number of members on the server`;
+	describe(interaction, name) {
+		const description = `Type \`/${name}\` to know the number of members on the server`;
+		return {name, description};
 	}
 }

--- a/commands/help.js
+++ b/commands/help.js
@@ -1,5 +1,9 @@
 import Command from "../command.js";
 export default class HelpCommand extends Command {
+	register(client, name) {
+		const description = "Tells you what are the features I offer";
+		return {name, description};
+	}
 	async execute(interaction) {
 		const {client, user} = interaction;
 		const {commands, feeds, grants, triggers} = client;
@@ -9,7 +13,7 @@ export default class HelpCommand extends Command {
 			Object.entries(feeds),
 			Object.entries(triggers),
 		].flat().map(([name, action]) => {
-			const {description} = action.describe(interaction, name);
+			const description = action.describe(interaction, name);
 			if (description === null) {
 				return [];
 			}
@@ -20,7 +24,6 @@ export default class HelpCommand extends Command {
 		await interaction.reply(`Hey ${user}, there you are!\nI can give you some advice about the server:\n${featureList}`);
 	}
 	describe(interaction, name) {
-		const description = `Type \`/${name}\` to know the features I offer`;
-		return {name, description};
+		return `Type \`/${name}\` to know what are the features I offer`;
 	}
 }

--- a/commands/leaderboard.js
+++ b/commands/leaderboard.js
@@ -10,13 +10,17 @@ const leaderboards = [
 	"*Category Extensions leaderboard*: https://www.speedrun.com/sbace",
 ];
 export default class LeaderboardCommand extends Command {
-	async execute(message, parameters) {
-		const links = leaderboards.map((leaderboard) => {
+	async execute(interaction) {
+		const linkList = leaderboards.map((leaderboard) => {
 			return `- ${leaderboard}`;
 		}).join("\n");
-		await (await message.reply(`You can watch community speedruns there:\n${links}`)).suppressEmbeds(true);
+		await (await interaction.reply({
+			content: `You can watch community speedruns there:\n${linkList}`,
+			fetchReply: true,
+		})).suppressEmbeds(true);
 	}
-	async describe(message, command) {
-		return `Type \`${command}\` to know where to watch community speedruns of the game`;
+	describe(interaction, name) {
+		const description = `Type \`/${name}\` to know where to watch community speedruns of the game`;
+		return {name, description};
 	}
 }

--- a/commands/leaderboard.js
+++ b/commands/leaderboard.js
@@ -10,6 +10,10 @@ const leaderboards = [
 	"*Category Extensions leaderboard*: https://www.speedrun.com/sbace",
 ];
 export default class LeaderboardCommand extends Command {
+	register(client, name) {
+		const description = "Tells you where to watch community speedruns of the game";
+		return {name, description};
+	}
 	async execute(interaction) {
 		const linkList = leaderboards.map((leaderboard) => {
 			return `- ${leaderboard}`;
@@ -20,7 +24,6 @@ export default class LeaderboardCommand extends Command {
 		})).suppressEmbeds(true);
 	}
 	describe(interaction, name) {
-		const description = `Type \`/${name}\` to know where to watch community speedruns of the game`;
-		return {name, description};
+		return `Type \`/${name}\` to know where to watch community speedruns of the game`;
 	}
 }

--- a/commands/mission.js
+++ b/commands/mission.js
@@ -17,6 +17,17 @@ const timeFormat = new Intl.DateTimeFormat("en-US", {
 });
 const dayTime = timeFormat.format(new Date(36000000));
 export default class MissionCommand extends Command {
+	register(client, name) {
+		const description = "Tells you what is playable in the shop or when it is playable";
+		const options = [
+			{
+				type: "STRING",
+				name: "mission",
+				description: "Some mission",
+			},
+		];
+		return {name, description, options};
+	}
 	async execute(interaction) {
 		const {client, options} = interaction;
 		const {data} = client;
@@ -64,14 +75,6 @@ export default class MissionCommand extends Command {
 		await interaction.reply(`**${Util.escapeMarkdown(challenge)}** in **${Util.escapeMarkdown(level)}** will be playable for 1 day starting:\n${scheduleList}`);
 	}
 	describe(interaction, name) {
-		const description = `Type \`/${name}\` to know what is playable in the shop\nType \`/${name} Some mission\` to know when \`Some mission\` is playable in the shop`;
-		const options = [
-			{
-				type: "STRING",
-				name: "mission",
-				description: "Some mission",
-			},
-		];
-		return {name, description, options};
+		return `Type \`/${name}\` to know what is playable in the shop\nType \`/${name} Some mission\` to know when \`Some mission\` is playable in the shop`;
 	}
 }

--- a/commands/outfit.js
+++ b/commands/outfit.js
@@ -70,6 +70,17 @@ function sliceOutfits(generator, outfits, outfitsPerSlice, slicesPerRarity) {
 	return slices;
 }
 export default class OutfitCommand extends Command {
+	register(client, name) {
+		const description = "Tells you what is for sale in the shop or when it is for sale";
+		const options = [
+			{
+				type: "STRING",
+				name: "outfit",
+				description: "Some outfit",
+			},
+		];
+		return {name, description, options};
+	}
 	async execute(interaction) {
 		const {client, options} = interaction;
 		const {data, indices, salt} = client;
@@ -165,14 +176,6 @@ export default class OutfitCommand extends Command {
 		await interaction.reply(`**${Util.escapeMarkdown(name)}** will be for sale in the shop${costConjunction} for 6 hours starting:\n${scheduleList}`);
 	}
 	describe(interaction, name) {
-		const description = `Type \`/${name}\` to know what is for sale in the shop\nType \`/${name} Some outfit\` to know when \`Some outfit\` is for sale in the shop`;
-		const options = [
-			{
-				type: "STRING",
-				name: "outfit",
-				description: "Some outfit",
-			},
-		];
-		return {name, description, options};
+		return `Type \`/${name}\` to know what is for sale in the shop\nType \`/${name} Some outfit\` to know when \`Some outfit\` is for sale in the shop`;
 	}
 }

--- a/commands/raw.js
+++ b/commands/raw.js
@@ -1,41 +1,65 @@
 import discord from "discord.js";
 import Command from "../command.js";
 const {Util} = discord;
-const listFormat = new Intl.ListFormat("en-US", {
+const conjunctionFormat = new Intl.ListFormat("en-US", {
 	style: "long",
 	type: "conjunction",
 });
-const pattern = /^(?:0|[1-9]\d*)$/;
 export default class RawCommand extends Command {
-	async execute(message, parameters) {
-		const {data} = message.client;
-		if (parameters.length < 2) {
-			const type = listFormat.format(Object.keys(data).map((type) => {
+	async execute(interaction) {
+		const {client, options} = interaction;
+		const {data} = client;
+		const type = options.getString("type");
+		if (!(type in data)) {
+			const typeConjunction = conjunctionFormat.format(Object.keys(data).map((type) => {
 				return `\`${Util.escapeMarkdown(type)}\``;
 			}));
-			await message.reply(`Please give me a type among ${type}.`);
-			return;
-		}
-		const type = parameters[1].toLowerCase();
-		if (!(type in data)) {
-			await message.reply(`I do not know any type with this name.`);
+			await interaction.reply({
+				content: `I do not know any datum with this name.\nPlease give me a type among ${typeConjunction} instead.`,
+				ephemeral: true,
+			});
 			return;
 		}
 		const array = data[type];
-		if (parameters.length < 3) {
-			await message.reply(`Please give me an identifier${array.length > 0 ? ` between \`0\` and \`${array.length - 1}\`` : ""}.`);
+		const identifier = options.getInteger("identifier");
+		if (identifier < 0 || identifier >= array.length) {
+			await interaction.reply({
+				content: `I do not know any datum with this identifier.\nPlease give me an identifier between \`0\` and \`${array.length - 1}\` instead.`,
+				ephemeral: true,
+			});
 			return;
 		}
-		const identifier = parameters[2];
-		const matches = identifier.match(pattern);
-		if (matches === null || Number(identifier) >= array.length) {
-			await message.reply(`I do not know any datum with this identifier.`);
-			return;
-		}
-		const datum = Util.escapeMarkdown(JSON.stringify(array[identifier], null, "\t"));
-		await message.reply(`\`\`\`json\n${datum}\n\`\`\``);
+		const datum = JSON.stringify(array[identifier], null, "\t");
+		await interaction.reply(`\`\`\`json\n${Util.escapeMarkdown(datum)}\n\`\`\``);
 	}
-	async describe(message, command) {
-		return `Type \`${command} Some type Some identifier\` to get the datum of \`Some type\` with \`Some identifier\``;
+	describe(interaction, name) {
+		const {client} = interaction;
+		const {data} = client;
+		const description = `Type \`/${name} Some type Some identifier\` to get the datum of \`Some type\` with \`Some identifier\``;
+		const options = [
+			{
+				type: "STRING",
+				name: "type",
+				description: "Some type",
+				required: true,
+				choices: Object.entries(data).filter(([type, array]) => {
+					return array.length !== 0;
+				}).map(([type, array]) => {
+					return {
+						name: type,
+						value: type,
+					};
+				}),
+			},
+			{
+				type: "INTEGER",
+				name: "identifier",
+				description: "Some identifier",
+				required: true,
+				min_value: 0,
+				minValue: 0,
+			},
+		];
+		return {name, description, options};
 	}
 }

--- a/commands/raw.js
+++ b/commands/raw.js
@@ -6,6 +6,35 @@ const conjunctionFormat = new Intl.ListFormat("en-US", {
 	type: "conjunction",
 });
 export default class RawCommand extends Command {
+	register(client, name) {
+		const {data} = client;
+		const description = "Tells you what is the datum of this type with this identifier";
+		const options = [
+			{
+				type: "STRING",
+				name: "type",
+				description: "Some type",
+				required: true,
+				choices: Object.entries(data).filter(([type, array]) => {
+					return array.length !== 0;
+				}).map(([type, array]) => {
+					return {
+						name: type,
+						value: type,
+					};
+				}),
+			},
+			{
+				type: "INTEGER",
+				name: "identifier",
+				description: "Some identifier",
+				required: true,
+				min_value: 0,
+				minValue: 0,
+			},
+		];
+		return {name, description, options};
+	}
 	async execute(interaction) {
 		const {client, options} = interaction;
 		const {data} = client;
@@ -33,33 +62,6 @@ export default class RawCommand extends Command {
 		await interaction.reply(`\`\`\`json\n${Util.escapeMarkdown(datum)}\n\`\`\``);
 	}
 	describe(interaction, name) {
-		const {client} = interaction;
-		const {data} = client;
-		const description = `Type \`/${name} Some type Some identifier\` to get the datum of \`Some type\` with \`Some identifier\``;
-		const options = [
-			{
-				type: "STRING",
-				name: "type",
-				description: "Some type",
-				required: true,
-				choices: Object.entries(data).filter(([type, array]) => {
-					return array.length !== 0;
-				}).map(([type, array]) => {
-					return {
-						name: type,
-						value: type,
-					};
-				}),
-			},
-			{
-				type: "INTEGER",
-				name: "identifier",
-				description: "Some identifier",
-				required: true,
-				min_value: 0,
-				minValue: 0,
-			},
-		];
-		return {name, description, options};
+		return `Type \`/${name} Some type Some identifier\` to know what is the datum of \`Some type\` with \`Some identifier\``;
 	}
 }

--- a/commands/roadmap.js
+++ b/commands/roadmap.js
@@ -1,5 +1,9 @@
 import Command from "../command.js";
 export default class RoadmapCommand extends Command {
+	register(client, name) {
+		const description = "Tells you where to check the upcoming milestones of the game";
+		return {name, description};
+	}
 	async execute(interaction) {
 		const channel = interaction.guild.channels.cache.find((channel) => {
 			return channel.name === "🤔suggestions";
@@ -17,7 +21,6 @@ export default class RoadmapCommand extends Command {
 		})).suppressEmbeds(true);
 	}
 	describe(interaction, name) {
-		const description = `Type \`/${name}\` to know where to check the upcoming milestones of the game`;
-		return {name, description};
+		return `Type \`/${name}\` to know where to check the upcoming milestones of the game`;
 	}
 }

--- a/commands/roadmap.js
+++ b/commands/roadmap.js
@@ -1,16 +1,23 @@
 import Command from "../command.js";
 export default class RoadmapCommand extends Command {
-	async execute(message, parameters) {
-		const channel = message.guild.channels.cache.find((channel) => {
+	async execute(interaction) {
+		const channel = interaction.guild.channels.cache.find((channel) => {
 			return channel.name === "🤔suggestions";
 		});
 		if (typeof channel !== "undefined") {
-			await (await message.reply(`Before suggesting an idea in ${channel}, check the upcoming milestones of the game there:\nhttps://trello.com/b/3DPL9CwV/road-to-100`)).suppressEmbeds(true);
+			await (await interaction.reply({
+				content: `Before suggesting an idea in ${channel}, check the upcoming milestones of the game there:\nhttps://trello.com/b/3DPL9CwV/road-to-100`,
+				fetchReply: true,
+			})).suppressEmbeds(true);
 			return;
 		}
-		await (await message.reply("You can check the upcoming milestones of the game there:\nhttps://trello.com/b/3DPL9CwV/road-to-100")).suppressEmbeds(true);
+		await (await interaction.reply({
+			content: "You can check the upcoming milestones of the game there:\nhttps://trello.com/b/3DPL9CwV/road-to-100",
+			fetchReply: true,
+		})).suppressEmbeds(true);
 	}
-	async describe(message, command) {
-		return `Type \`${command}\` to know where to check the upcoming milestones of the game`;
+	describe(interaction, name) {
+		const description = `Type \`/${name}\` to know where to check the upcoming milestones of the game`;
+		return {name, description};
 	}
 }

--- a/commands/store.js
+++ b/commands/store.js
@@ -4,6 +4,10 @@ const stores = [
 	"*American and Oceanian store*: https://shop.spreadshirt.com/SuperBearAdventure",
 ];
 export default class StoreCommand extends Command {
+	register(client, name) {
+		const description = "Tells you where to buy offical products of the game";
+		return {name, description};
+	}
 	async execute(interaction) {
 		const linkList = stores.map((store) => {
 			return `- ${store}`;
@@ -14,7 +18,6 @@ export default class StoreCommand extends Command {
 		})).suppressEmbeds(true);
 	}
 	describe(interaction, name) {
-		const description = `Type \`/${name}\` to know where to buy offical products of the game`;
-		return {name, description};
+		return `Type \`/${name}\` to know where to buy offical products of the game`;
 	}
 }

--- a/commands/store.js
+++ b/commands/store.js
@@ -4,13 +4,17 @@ const stores = [
 	"*American and Oceanian store*: https://shop.spreadshirt.com/SuperBearAdventure",
 ];
 export default class StoreCommand extends Command {
-	async execute(message, parameters) {
-		const links = stores.map((store) => {
+	async execute(interaction) {
+		const linkList = stores.map((store) => {
 			return `- ${store}`;
 		}).join("\n");
-		await (await message.reply(`You can buy official products of the game there:\n${links}`)).suppressEmbeds(true);
+		await (await interaction.reply({
+			content: `You can buy official products of the game there:\n${linkList}`,
+			fetchReply: true,
+		})).suppressEmbeds(true);
 	}
-	async describe(message, command) {
-		return `Type \`${command}\` to know where to buy offical products of the game`;
+	describe(interaction, name) {
+		const description = `Type \`/${name}\` to know where to buy offical products of the game`;
+		return {name, description};
 	}
 }

--- a/commands/tracker.js
+++ b/commands/tracker.js
@@ -4,20 +4,27 @@ const trackers = [
 	"*Former tracker*: https://trello.com/b/yTojOuqv/super-bear-adventure-bugs",
 ];
 export default class TrackerCommand extends Command {
-	async execute(message, parameters) {
-		const links = trackers.map((tracker) => {
+	async execute(interaction) {
+		const linkList = trackers.map((tracker) => {
 			return `- ${tracker}`;
 		}).join("\n");
-		const channel = message.guild.channels.cache.find((channel) => {
+		const channel = interaction.guild.channels.cache.find((channel) => {
 			return channel.name === "🐛bug-report";
 		});
 		if (typeof channel !== "undefined") {
-			await (await message.reply(`Before reporting a bug in ${channel}, check the known bugs of the game there:\n${links}`)).suppressEmbeds(true);
+			await (await interaction.reply({
+				content: `Before reporting a bug in ${channel}, check the known bugs of the game there:\n${linkList}`,
+				fetchReply: true,
+			})).suppressEmbeds(true);
 			return;
 		}
-		await (await message.reply(`You can check known bugs of the game there:\n${links}`)).suppressEmbeds(true);
+		await (await interaction.reply({
+			content: `You can check known bugs of the game there:\n${linkList}`,
+			fetchReply: true,
+		})).suppressEmbeds(true);
 	}
-	async describe(message, command) {
-		return `Type \`${command}\` to know where to check known bugs of the game`;
+	describe(interaction, name) {
+		const description = `Type \`/${name}\` to know where to check known bugs of the game`;
+		return {name, description};
 	}
 }

--- a/commands/tracker.js
+++ b/commands/tracker.js
@@ -4,6 +4,10 @@ const trackers = [
 	"*Former tracker*: https://trello.com/b/yTojOuqv/super-bear-adventure-bugs",
 ];
 export default class TrackerCommand extends Command {
+	register(client, name) {
+		const description = "Tells you where to check known bugs of the game";
+		return {name, description};
+	}
 	async execute(interaction) {
 		const linkList = trackers.map((tracker) => {
 			return `- ${tracker}`;
@@ -24,7 +28,6 @@ export default class TrackerCommand extends Command {
 		})).suppressEmbeds(true);
 	}
 	describe(interaction, name) {
-		const description = `Type \`/${name}\` to know where to check known bugs of the game`;
-		return {name, description};
+		return `Type \`/${name}\` to know where to check known bugs of the game`;
 	}
 }

--- a/commands/trailer.js
+++ b/commands/trailer.js
@@ -4,13 +4,17 @@ const trailers = [
 	"*Missions trailer*: https://www.youtube.com/watch?v=j3vwu0JWIEg",
 ];
 export default class TrailerCommand extends Command {
-	async execute(message, parameters) {
-		const links = trailers.map((trailer) => {
+	async execute(interaction) {
+		const linkList = trailers.map((trailer) => {
 			return `- ${trailer}`;
 		}).join("\n");
-		await (await message.reply(`You can watch official trailers of the game there:\n${links}`)).suppressEmbeds(true);
+		await (await interaction.reply({
+			content: `You can watch official trailers of the game there:\n${linkList}`,
+			fetchReply: true,
+		})).suppressEmbeds(true);
 	}
-	async describe(message, command) {
-		return `Type \`${command}\` to know where to watch official trailers of the game`;
+	describe(interaction, name) {
+		const description = `Type \`/${name}\` to know where to watch official trailers of the game`;
+		return {name, description};
 	}
 }

--- a/commands/trailer.js
+++ b/commands/trailer.js
@@ -4,6 +4,10 @@ const trailers = [
 	"*Missions trailer*: https://www.youtube.com/watch?v=j3vwu0JWIEg",
 ];
 export default class TrailerCommand extends Command {
+	register(client, name) {
+		const description = "Tells you where to watch official trailers of the game";
+		return {name, description};
+	}
 	async execute(interaction) {
 		const linkList = trailers.map((trailer) => {
 			return `- ${trailer}`;
@@ -14,7 +18,6 @@ export default class TrailerCommand extends Command {
 		})).suppressEmbeds(true);
 	}
 	describe(interaction, name) {
-		const description = `Type \`/${name}\` to know where to watch official trailers of the game`;
-		return {name, description};
+		return `Type \`/${name}\` to know where to watch official trailers of the game`;
 	}
 }

--- a/commands/update.js
+++ b/commands/update.js
@@ -9,6 +9,10 @@ const dateFormat = new Intl.DateTimeFormat("en-US", {
 	timeZone: "UTC",
 });
 export default class UpdateCommand extends Command {
+	register(client, name) {
+		const description = "Tells you what is the latest update of the game";
+		return {name, description};
+	}
 	async execute(interaction) {
 		try {
 			const {window} = await JSDOM.fromURL("https://play.google.com/store/apps/details?id=com.Earthkwak.Platformer");
@@ -40,7 +44,6 @@ export default class UpdateCommand extends Command {
 		}
 	}
 	describe(interaction, name) {
-		const description = `Type \`/${name}\` to check the latest update of the game`;
-		return {name, description};
+		return `Type \`/${name}\` to know what is the latest update of the game`;
 	}
 }

--- a/commands/update.js
+++ b/commands/update.js
@@ -9,7 +9,7 @@ const dateFormat = new Intl.DateTimeFormat("en-US", {
 	timeZone: "UTC",
 });
 export default class UpdateCommand extends Command {
-	async execute(message, parameters) {
+	async execute(interaction) {
 		try {
 			const {window} = await JSDOM.fromURL("https://play.google.com/store/apps/details?id=com.Earthkwak.Platformer");
 			const versionElement = window.document.querySelector(".IxB2fe > :nth-child(4) > :nth-child(2) > :nth-child(1) > :nth-child(1)");
@@ -21,22 +21,26 @@ export default class UpdateCommand extends Command {
 				throw new Error("No date found");
 			}
 			const response = await fetch("https://itunes.apple.com/lookup?id=1531842415&entity=software");
-			const {resultCount, results} = await response.json();
-			if (resultCount === 0) {
+			const {results} = await response.json();
+			if (results.length === 0) {
 				throw new Error("No result found");
 			}
 			const result = results[0];
-			const androidVersion = `**${Util.escapeMarkdown(versionElement.textContent)}**`;
-			const androidDate = `*${Util.escapeMarkdown(dateElement.textContent)}*`;
-			const iosVersion = `**${Util.escapeMarkdown(result.version)}**`;
-			const iosDate = `*${Util.escapeMarkdown(dateFormat.format(new Date (result.currentVersionReleaseDate)))}*`;
-			await message.reply(`The latest update of the game is:\n- ${androidVersion} (${androidDate}) on *Android*\n- ${iosVersion} (${iosDate}) on *iOS*`);
+			const androidVersion = versionElement.textContent;
+			const androidDate = dateElement.textContent;
+			const iosVersion = result.version;
+			const iosDate = dateFormat.format(new Date(result.currentVersionReleaseDate));
+			await interaction.reply(`The latest update of the game is:\n- **${Util.escapeMarkdown(androidVersion)}** on **Android** (*${Util.escapeMarkdown(androidDate)}*)\n- **${Util.escapeMarkdown(iosVersion)}** on **iOS** (*${Util.escapeMarkdown(iosDate)}*)`);
 		} catch (error) {
 			console.warn(error);
-			await (await message.reply("You can check and download the latest update of the game there:\n- *Android*: https://play.google.com/store/apps/details?id=com.Earthkwak.Platformer\n- *iOS*: https://apps.apple.com/app/id1531842415")).suppressEmbeds(true);
+			await (await interaction.reply({
+				content: "You can check and download the latest update of the game there:\n- *Android*: https://play.google.com/store/apps/details?id=com.Earthkwak.Platformer\n- *iOS*: https://apps.apple.com/app/id1531842415",
+				fetchReply: true,
+			})).suppressEmbeds(true);
 		}
 	}
-	async describe(message, command) {
-		return `Type \`${command}\` to check the latest update of the game`;
+	describe(interaction, name) {
+		const description = `Type \`/${name}\` to check the latest update of the game`;
+		return {name, description};
 	}
 }

--- a/feed.js
+++ b/feed.js
@@ -1,7 +1,5 @@
 export default class Feed {
 	schedule(client) {}
 	async execute(start, end) {}
-	async describe(message) {
-		return "";
-	}
+	describe(interaction, name) {}
 }

--- a/feed.js
+++ b/feed.js
@@ -1,5 +1,5 @@
 export default class Feed {
-	schedule(client) {}
+	register(client, name) {}
 	async execute(start, end) {}
 	describe(interaction, name) {}
 }

--- a/feeds/record.js
+++ b/feeds/record.js
@@ -5,7 +5,7 @@ import Feed from "../feed.js";
 const {Util} = discord;
 const games = ["9d3rrxyd", "w6jl2ned"];
 export default class RecordFeed extends Feed {
-	schedule(client) {
+	register(client, name) {
 		return schedule.scheduleJob({
 			rule: "1 3/6 * * *",
 			tz: "UTC",
@@ -122,7 +122,6 @@ export default class RecordFeed extends Feed {
 		const channel = interaction.guild.channels.cache.find((channel) => {
 			return channel.name === "🏅records";
 		});
-		const description = typeof channel !== "undefined" ? `I post the latest world records of the game in ${channel}` : null;
-		return {description};
+		return typeof channel !== "undefined" ? `I post the latest world records of the game in ${channel}` : null;
 	}
 }

--- a/grant.js
+++ b/grant.js
@@ -1,4 +1,4 @@
 export default class Command {
-	async execute(interaction) {}
+	async execute(message, parameters) {}
 	describe(interaction, name) {}
 }

--- a/grants/chat.js
+++ b/grants/chat.js
@@ -72,7 +72,6 @@ export default class ChatGrant extends Grant {
 		await (await channel.send({content, files})).suppressEmbeds(true);
 	}
 	describe(interaction, name) {
-		const description = channels.has(interaction.channel.name) ? `Type \`/${name} Some channel Some content\` to post \`Some content\` and some attachments in \`Some channel\`\nType \`/${name} Some message Some channel Some content\` to edit \`Some message\` with \`Some content\` in \`Some channel\`` : null;
-		return {name, description};
+		return channels.has(interaction.channel.name) ? `Type \`/${name} Some channel Some content\` to post \`Some content\` and some attachments in \`Some channel\`\nType \`/${name} Some message Some channel Some content\` to edit \`Some message\` with \`Some content\` in \`Some channel\`` : null;
 	}
 }

--- a/grants/chat.js
+++ b/grants/chat.js
@@ -1,11 +1,11 @@
 import discord from "discord.js";
-import Command from "../command.js";
+import Grant from "../grant.js";
 const {MessageMentions} = discord;
 const {source} = MessageMentions.CHANNELS_PATTERN;
 const messagePattern = /^(?:0|[1-9]\d*)$/;
 const channelPattern = new RegExp(`^(?:${source})$`, "");
 const channels = new Set(["🔎logs", "🛡moderators-room"]);
-export default class ChatCommand extends Command {
+export default class ChatGrant extends Grant {
 	async execute(message, parameters) {
 		if (!channels.has(message.channel.name)) {
 			return;
@@ -45,7 +45,7 @@ export default class ChatCommand extends Command {
 				return;
 			}
 			if (parameters.length < 4 && target.attachments.size === 0) {
-				await message.reply(`Please give me an inline message.`);
+				await message.reply(`Please give me a content.`);
 				return;
 			}
 			const content = parameters.length < 4 ? null : parameters.slice(3).join(" ");
@@ -58,7 +58,7 @@ export default class ChatCommand extends Command {
 			return;
 		}
 		if (parameters.length < 3 && message.attachments.size === 0) {
-			await message.reply(`Please give me an inline message or attachments.`);
+			await message.reply(`Please give me a content or attachments.`);
 			return;
 		}
 		const content = parameters.length < 3 ? null : parameters.slice(2).join(" ");
@@ -71,10 +71,8 @@ export default class ChatCommand extends Command {
 		});
 		await (await channel.send({content, files})).suppressEmbeds(true);
 	}
-	async describe(message, command) {
-		if (!channels.has(message.channel.name)) {
-			return "";
-		}
-		return `Type \`${command} Some channel Some text\` to post \`Some text\` and some attachments in \`Some channel\`\nType \`${command} Some message Some channel Some text\` to edit \`Some message\` with \`Some text\` in \`Some channel\``;
+	describe(interaction, name) {
+		const description = channels.has(interaction.channel.name) ? `Type \`/${name} Some channel Some content\` to post \`Some content\` and some attachments in \`Some channel\`\nType \`/${name} Some message Some channel Some content\` to edit \`Some message\` with \`Some content\` in \`Some channel\`` : null;
+		return {name, description};
 	}
 }

--- a/grants/emoji.js
+++ b/grants/emoji.js
@@ -4,7 +4,7 @@ import canvas from "canvas";
 import discord from "discord.js";
 import jsdom from "jsdom";
 import serialize from "w3c-xmlserializer";
-import Command from "../command.js";
+import Grant from "../grant.js";
 const {readFile} = fs;
 const {fileURLToPath} = url;
 const {createCanvas, loadImage} = canvas;
@@ -12,7 +12,7 @@ const {Util} = discord;
 const {JSDOM} = jsdom;
 const here = import.meta.url;
 const root = here.slice(0, here.lastIndexOf("/"));
-const listFormat = new Intl.ListFormat("en-US", {
+const conjunctionFormat = new Intl.ListFormat("en-US", {
 	style: "long",
 	type: "conjunction",
 });
@@ -31,19 +31,19 @@ const styles = Object.assign(Object.create(null), {
 	"none": "none",
 });
 const channels = new Set(["🔎logs", "🛡moderators-room", "🍪cookie-room"]);
-export default class EmojiCommand extends Command {
+export default class EmojiGrant extends Grant {
 	async execute(message, parameters) {
 		if (!channels.has(message.channel.name)) {
 			return;
 		}
 		if (parameters.length < 2) {
-			const base = listFormat.format(Array.from(bases.keys()).map((base) => {
+			const baseConjunction = conjunctionFormat.format(Array.from(bases.keys()).map((base) => {
 				return `\`${Util.escapeMarkdown(base)}\``;
 			}));
-			const style = listFormat.format(Object.keys(styles).concat("auto").map((style) => {
+			const styleConjunction = conjunctionFormat.format(Object.keys(styles).concat("auto").map((style) => {
 				return `\`${Util.escapeMarkdown(style)}\``;
 			}));
-			await message.channel.send(`Please give me:\n- a base among ${base}\n- up to 6 styles among ${style}`);
+			await message.channel.send(`Please give me:\n- a base among ${baseConjunction}\n- up to 6 styles among ${styleConjunction}`);
 			return;
 		}
 		const base = parameters[1].toLowerCase();
@@ -87,7 +87,7 @@ export default class EmojiCommand extends Command {
 		const canvas = createCanvas(width, height);
 		const context = canvas.getContext("2d");
 		context.drawImage(image, 0, 0, width, height);
-		await message.channel.send({
+		await message.reply({
 			files: [
 				{
 					attachment: canvas.toBuffer(),
@@ -96,10 +96,8 @@ export default class EmojiCommand extends Command {
 			],
 		});
 	}
-	async describe(message, command) {
-		if (!channels.has(message.channel.name)) {
-			return "";
-		}
-		return `Type \`${command} Some base Some styles\` to create a new \`Some base\`-based emoji customized with \`Some styles\``;
+	describe(interaction, name) {
+		const description = channels.has(interaction.channel.name) ? `Type \`/${name} Some base Some styles\` to create a new \`Some base\`-based emoji customized with \`Some styles\`` : null;
+		return {name, description};
 	}
 }

--- a/grants/emoji.js
+++ b/grants/emoji.js
@@ -97,7 +97,6 @@ export default class EmojiGrant extends Grant {
 		});
 	}
 	describe(interaction, name) {
-		const description = channels.has(interaction.channel.name) ? `Type \`/${name} Some base Some styles\` to create a new \`Some base\`-based emoji customized with \`Some styles\`` : null;
-		return {name, description};
+		return channels.has(interaction.channel.name) ? `Type \`/${name} Some base Some styles\` to create a new \`Some base\`-based emoji customized with \`Some styles\`` : null;
 	}
 }

--- a/readme.md
+++ b/readme.md
@@ -4,14 +4,13 @@ Bot for the official *Super Bear Adventure* *Discord* server
 
 ## Dependencies
 
-The bot uses *Discord.js 12* and requires *Node.js 15.0.0* or more
+The bot uses *Discord.js 13.2.0* and requires *Node.js 16.9.0* or more
 
 ## Configuring the bot
 
 ```shell
-$ export SHICKA_DISCORD_TOKEN=<your-token-here>
-$ export SHICKA_PREFIX="?"
-$ export SHICKA_SALT="0"
+$ export SHICKA_DISCORD_TOKEN=<your-discord-token-here>
+$ export SHICKA_SALT=<your-salt-here>
 ```
 
 ## Starting the bot
@@ -22,41 +21,43 @@ $ node shicka.js
 
 ## Features
 
+### Grants
+
+- `/chat <channel> <content>` writes the given content and uploads the given attachments in the given channel (only available in the `#🔎logs` and `#🛡moderators-room` channels)
+
+- `/chat <message> <channel> <content>` edits the given message with the given content in the given channel (only available in the `#🔎logs` and `#🛡moderators-room` channels)
+
+- `/emoji <base> <style>` draws the given base emoji with the given style (only available in the `#🔎logs`, `#🛡moderators-room`, and `#🍪cookie-room` channels)
+
 ### Commands
 
-- `?about` gives the link to this repository on `github.com`
+- `/about` gives the link to this repository on `github.com`
 
-- `?chat <channel> <text>` writes the given text and uploads the given attachments in the given channel (only available in the `#🔎logs` and `#🛡moderators-room` channels)
+- `/count` gives the number of members of the guild
 
-- `?chat <message> <channel> <text>` edits the given message with the given text in the given channel (only available in the `#🔎logs` and `#🛡moderators-room` channels)
+- `/help` gives the feature list of this bot
 
-- `?count` gives the number of members of the guild
+- `/leaderboard` gives the links to the speedrun leaderboards of the game on `www.speedrun.com`
 
-- `?emoji <base> <style>` draws the given base emoji with the given style (only available in the `#🔎logs`, `#🛡moderators-room`, and `#🍪cookie-room` channels)
+- `/mission` gives the schedule of the next three missions in the shop
 
-- `?help` gives the feature list of this bot
+- `/mission <mission>` gives the schedule of at least the next two occurences of the given mission in the shop
 
-- `?leaderboard` gives the links to the speedrun leaderboards of the game on `www.speedrun.com`
+- `/outfit` gives the schedule of the next six sets of outfits in the shop
 
-- `?mission` gives the schedule of the next three missions
+- `/outfit <outfit>` gives the schedule of at least the next two occurrences of the given outfit in the shop
 
-- `?mission <mission>` gives the schedule of at least the next two occurences of the given mission
+- `/raw <type> <identifier>` gives the datum of the given type with the given identifier
 
-- `?outfit` gives the schedule of the next six sets of outfits in the shop
+- `/roadmap` gives the link to the todo list of the game on `trello.com`
 
-- `?outfit <outfit>` gives the schedule of at least the next two occurrences of the given outfit in the shop
+- `/store` gives the links to the online stores of the game on `shop.spreadshirt.net` and `shop.spreadshirt.com`
 
-- `?raw <type> <identifier>` gives the datum of the given type with the given identifier
+- `/tracker` gives the links to the issue trackers of the game on `github.com` and `trello.com`
 
-- `?roadmap` gives the link to the todo list of the game on `trello.com`
+- `/trailer` gives the links to the trailers of the game on `www.youtube.com`
 
-- `?store` gives the links to the online stores of the game on `shop.spreadshirt.net` and `shop.spreadshirt.com`
-
-- `?tracker` gives the links to the issue trackers of the game on `github.com` and `trello.com`
-
-- `?trailer` gives the links to the trailers of the game on `www.youtube.com`
-
-- `?update` checks the latest releases of the game on `play.google.com` and `itunes.apple.com`
+- `/update` checks the latest releases of the game on `play.google.com` and `itunes.apple.com`
 
 ### Feeds
 

--- a/shicka.js
+++ b/shicka.js
@@ -70,15 +70,13 @@ client.once("ready", async (client) => {
 	console.log("Ready!");
 	const {commands, feeds} = client;
 	const menu = Object.entries(commands).map(([name, command]) => {
-		const item = command.describe({client}, name);
-		item.description = item.description.slice(0, 100);
-		return item;
+		return command.register(client, name);
 	});
 	for (const guild of client.guilds.cache.values()) {
 		guild.commands.set(menu);
 	}
-	for (const feed in feeds) {
-		const job = feeds[feed].schedule(client);
+	for (const [name, feed] of Object.entries(feeds)) {
+		const job = feed.register(client, name);
 		job.on("error", (error) => {
 			console.error(error);
 		});

--- a/trigger.js
+++ b/trigger.js
@@ -1,6 +1,4 @@
 export default class Trigger {
-	async execute(message, parameters) {}
-	async describe(message) {
-		return "";
-	}
+	async execute(message) {}
+	describe(interaction, name) {}
 }

--- a/triggers/rule7.js
+++ b/triggers/rule7.js
@@ -40,7 +40,6 @@ export default class Rule7Trigger extends Trigger {
 		const channel = interaction.guild.channels.cache.find((channel) => {
 			return channel.name === "🤔suggestions";
 		});
-		const description = typeof channel !== "undefined" ? `I will gently reprimand you if you write words which violate the rule 7 in ${channel}` : null;
-		return {description};
+		return typeof channel !== "undefined" ? `I will gently reprimand you if you write words which violate the rule 7 in ${channel}` : null;
 	}
 }

--- a/triggers/rule7.js
+++ b/triggers/rule7.js
@@ -36,13 +36,11 @@ export default class Rule7Trigger extends Trigger {
 			await message.react(emoji);
 		}
 	}
-	async describe(message) {
-		const channel = message.guild.channels.cache.find((channel) => {
+	describe(interaction, name) {
+		const channel = interaction.guild.channels.cache.find((channel) => {
 			return channel.name === "🤔suggestions";
 		});
-		if (typeof channel === "undefined") {
-			return "";
-		}
-		return `I will gently reprimand you if you write words which violate the rule 7 in ${channel}`;
+		const description = typeof channel !== "undefined" ? `I will gently reprimand you if you write words which violate the rule 7 in ${channel}` : null;
+		return {description};
 	}
 }


### PR DESCRIPTION
Every command except `?chat` and `?emoji` has been reimplemented on top of guild slash commands.

These two commands have not been converted due to the lack of support for channel permissions and attachments in interactions.

They are still available as legacy commands (now called "grants"), but now with a `/` prefix instead of `?` to avoid having multiple prefixes.