### PR TITLE
Splits the `type` option of the `/raw` command into subcommands

### DIFF
--- a/src/commands/raw.ts
+++ b/src/commands/raw.ts
@@ -1,5 +1,5 @@
 import type {
-	ApplicationCommandOptionChoiceData,
+	ApplicationCommandSubCommandData,
 	ChatInputCommandInteraction,
 } from "discord.js";
 import type Binding from "../bindings.js";
@@ -16,95 +16,73 @@ import {
 import * as bindings from "../bindings.js";
 import {raw as rawCompilation} from "../compilations.js";
 import {raw as rawDefinition} from "../definitions.js";
-import {composeAll, localize, resolve} from "../utils/string.js";
+import {composeAll, localize} from "../utils/string.js";
 type HelpGroups = RawDependency["help"];
 const {
 	commandName,
 	commandDescription,
-	typeOptionName,
+	// typeOptionName,
 	typeOptionDescription,
 	identifierOptionName,
 	identifierOptionDescription,
 }: RawDefinition = rawDefinition;
 const {
 	help: helpLocalizations,
-	noTypeReply: noTypeReplyLocalizations,
-	noIdentifierReply: noIdentifierReplyLocalizations,
 }: RawCompilation = rawCompilation;
+function naiveSingularForm(pluralForm: string): string {
+	if (pluralForm.endsWith("ies")) {
+		return `${pluralForm.slice(0, -3)}y`;
+	}
+	return pluralForm.slice(0, -1);
+}
+function naivePluralForm(singularForm: string): string {
+	if (singularForm.endsWith("y")) {
+		return `${singularForm.slice(0, -1)}ies`;
+	}
+	return `${singularForm}s`;
+}
 const rawCommand: Command = {
 	register(): ApplicationCommandData {
 		return {
 			name: commandName,
 			description: commandDescription["en-US"],
 			descriptionLocalizations: commandDescription,
-			options: [
-				{
-					type: ApplicationCommandOptionType.String,
-					name: typeOptionName,
-					description: typeOptionDescription["en-US"],
-					descriptionLocalizations: typeOptionDescription,
-					required: true,
-					choices: Object.keys(bindings).map<[string, Binding]>((bindingName: string): [string, Binding] => {
-						const binding: Binding = bindings[bindingName as keyof typeof bindings];
-						return [bindingName, binding];
-					}).filter(([bindingName, binding]: [string, Binding]): boolean => {
-						return binding.length !== 0;
-					}).map<ApplicationCommandOptionChoiceData<string>>(([bindingName, binding]: [string, Binding]): ApplicationCommandOptionChoiceData<string> => {
-						return {
-							name: bindingName,
-							value: bindingName,
-						};
-					}),
-				},
-				{
-					type: ApplicationCommandOptionType.Integer,
-					name: identifierOptionName,
-					description: identifierOptionDescription["en-US"],
-					descriptionLocalizations: identifierOptionDescription,
-					required: true,
-					minValue: 0,
-				},
-			],
+			options: Object.keys(bindings).map<[string, Binding]>((bindingName: string): [string, Binding] => {
+				const binding: Binding = bindings[bindingName as keyof typeof bindings] as Binding;
+				return [bindingName, binding];
+			}).filter(([bindingName, binding]: [string, Binding]): boolean => {
+				return binding.length !== 0;
+			}).map<ApplicationCommandSubCommandData>(([bindingName, binding]: [string, Binding]): ApplicationCommandSubCommandData => {
+				const subCommandName: string = naiveSingularForm(bindingName);
+				const subCommandDescription: Localized<string> = commandDescription;
+				return {
+					type: ApplicationCommandOptionType.Subcommand,
+					name: subCommandName,
+					description: subCommandDescription["en-US"],
+					descriptionLocalizations: subCommandDescription,
+					options: [
+						{
+							type: ApplicationCommandOptionType.Integer,
+							name: identifierOptionName,
+							description: identifierOptionDescription["en-US"],
+							descriptionLocalizations: identifierOptionDescription,
+							required: true,
+							minValue: 0,
+							maxValue: binding.length - 1,
+						},
+					],
+				};
+			}),
 		};
 	},
 	async interact(interaction: ApplicationUserInteraction): Promise<void> {
 		if (!interaction.isChatInputCommand()) {
 			return;
 		}
-		const {locale, options}: ChatInputCommandInteraction<"cached"> = interaction;
-		const resolvedLocale: Locale = resolve(locale);
-		const bindingName: string = options.getString(typeOptionName, true);
-		if (!(bindingName in bindings)) {
-			const conjunctionFormat: Intl.ListFormat = new Intl.ListFormat(resolvedLocale, {
-				style: "long",
-				type: "conjunction",
-			});
-			await interaction.reply({
-				content: noTypeReplyLocalizations[resolvedLocale]({
-					typeConjunction: (): string => {
-						return conjunctionFormat.format(Object.keys(bindings).map<string>((bindingName: string): string => {
-							return `\`${escapeMarkdown(bindingName)}\``;
-						}));
-					},
-				}),
-				ephemeral: true,
-			});
-			return;
-		}
-		const binding: Binding = bindings[bindingName as keyof typeof bindings];
+		const {options}: ChatInputCommandInteraction<"cached"> = interaction;
+ 		const bindingName: string = naivePluralForm(options.getSubcommand(true));
+		const binding: Binding = bindings[bindingName as keyof typeof bindings] as Binding;
 		const identifier: number = options.getInteger(identifierOptionName, true);
-		if (identifier < 0 || identifier >= binding.length) {
-			const max: number = binding.length - 1;
-			await interaction.reply({
-				content: noIdentifierReplyLocalizations[resolvedLocale]({
-					max: (): string => {
-						return escapeMarkdown(`${max}`);
-					},
-				}),
-				ephemeral: true,
-			});
-			return;
-		}
 		const datum: string = JSON.stringify(binding[identifier], null, "\t");
 		await interaction.reply({
 			content: `\`\`\`json\n${escapeMarkdown(datum)}\n\`\`\``,

--- a/src/compilations/raw.ts
+++ b/src/compilations/raw.ts
@@ -3,19 +3,11 @@ import type {Localized} from "../utils/string.js";
 import {raw} from "../definitions.js";
 import {compileAll} from "../utils/string.js";
 type HelpLocalizations = Localized<(groups: Raw["help"]) => string>;
-type NoTypeReplyLocalizations = Localized<(groups: Raw["noTypeReply"]) => string>;
-type NoIdentifierReplyLocalizations = Localized<(groups: Raw["noIdentifierReply"]) => string>;
 type RawCompilation = {
 	help: HelpLocalizations,
-	noTypeReply: NoTypeReplyLocalizations,
-	noIdentifierReply: NoIdentifierReplyLocalizations,
 };
 const helpLocalizations: HelpLocalizations = compileAll<Raw["help"]>(raw["help"]);
-const noTypeReplyLocalizations: NoTypeReplyLocalizations = compileAll<Raw["noTypeReply"]>(raw["noTypeReply"]);
-const noIdentifierReplyLocalizations: NoIdentifierReplyLocalizations = compileAll<Raw["noIdentifierReply"]>(raw["noIdentifierReply"]);
 const rawCompilation: RawCompilation = {
 	help: helpLocalizations,
-	noTypeReply: noTypeReplyLocalizations,
-	noIdentifierReply: noIdentifierReplyLocalizations,
 };
 export default rawCompilation;

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -212,8 +212,6 @@ type Raw = {
 	identifierOptionName: string,
 	identifierOptionDescription: Localized<string>,
 	help: Localized<string>,
-	noTypeReply: Localized<string>,
-	noIdentifierReply: Localized<string>,
 };
 type Record = {
 	hookName: string,

--- a/src/definitions/raw.json
+++ b/src/definitions/raw.json
@@ -21,15 +21,5 @@
 		"en-US": "Type $<commandMention> `$<typeOptionDescription> $<identifierOptionDescription>` to know what is the datum of `$<typeOptionDescription>` with `$<identifierOptionDescription>`",
 		"fr": "Tape $<commandMention> `$<typeOptionDescription> $<identifierOptionDescription>` pour savoir quel est la donnée d'`$<typeOptionDescription>` avec `$<identifierOptionDescription>`",
 		"pt-BR": "Digite $<commandMention> `$<typeOptionDescription> $<identifierOptionDescription>` pra saber qual é o Datum de `$<typeOptionDescription>` com `$<identifierOptionDescription>`"
-	},
-	"noTypeReply": {
-		"en-US": "I do not know any datum with this name.\nPlease give me a type among $<typeConjunction> instead.",
-		"fr": "Je ne connais aucune donnée avec ce nom.\nMerci de me donner un type parmi $<typeConjunction> à la place.",
-		"pt-BR": "Eu não conheço nenhum Datum com esse nome.\nPor favor, me dê um tipo entre $<typeConjunction> em vez disso."
-	},
-	"noIdentifierReply": {
-		"en-US": "I do not know any datum with this identifier.\nPlease give me an identifier between `0` and `$<max>` instead.",
-		"fr": "Je ne connais aucune donnée avec cet identifiant.\nMerci de me donner un identifiant entre `0` et `$<max>` à la place.",
-		"pt-BR": "Eu não conheço nenhum Datum com esse nome.\nPor favor, me dê um tipo entre `0` e `$<max>` em vez disso."
 	}
 }

--- a/src/dependencies/raw.d.ts
+++ b/src/dependencies/raw.d.ts
@@ -11,7 +11,5 @@ type NoIdentifierReplyGroups = {
 };
 type RawDependency = {
 	help: HelpGroups,
-	noTypeReply: NoTypeReplyGroups,
-	noIdentifierReply: NoIdentifierReplyGroups,
 };
 export type {RawDependency as default};


### PR DESCRIPTION
This allows to enforce different min and max values for the `identifier` option of each type.

This have to wait for *Discord.js* to support ranges before landing.