### PR TITLE
Makes interaction replies and follow-ups immutable

### DIFF
--- a/grants/chat.js
+++ b/grants/chat.js
@@ -48,6 +48,10 @@ export default class ChatGrant extends Grant {
 				await message.reply(`I do not know any message with this identifier in this channel.`);
 				return;
 			}
+			if (target.interaction != null) {
+				await message.reply(`I can not edit interaction replies or follow-ups.`);
+				return;
+			}
 			if (parameters.length < 4 && message.attachments.size === 0) {
 				await message.reply(`Please give me a content or attachments.`);
 				return;


### PR DESCRIPTION
This prevents interaction replies from being edited by the `/chat` grant. Only messages previously sent with this grant should be editable by it.