### PR TITLE
Translates names and descriptions into French in application commands

### DIFF
--- a/src/commands/about.ts
+++ b/src/commands/about.ts
@@ -4,15 +4,23 @@ import type {
 	Interaction,
 } from "discord.js";
 import type Command from "../commands.js";
-const commandName: string = "about";
-const commandDescription: string = "Tells you where I come from";
+const commandNameLocalizations: {[k: string]: string} = {
+	"en-US": "about",
+	"fr": "à-propos",
+};
+const commandName: string = commandNameLocalizations["en-US"];
+const commandDescriptionLocalizations: {[k: string]: string} = {
+	"en-US": "Tells you where I come from",
+	"fr": "Te dit d'où je viens",
+};
+const commandDescription: string = commandDescriptionLocalizations["en-US"];
 function computeHelpLocalizations(): {[k in string]: () => string} {
 	return Object.assign(Object.create(null), {
 		"en-US"(): string {
-			return `Type \`/${commandName}\` to know where I come from`;
+			return `Type \`/${commandNameLocalizations["en-US"]}\` to know where I come from`;
 		},
 		"fr"(): string {
-			return `Tape \`/${commandName}\` pour savoir d'où je viens`;
+			return `Tape \`/${commandNameLocalizations["fr"]}\` pour savoir d'où je viens`;
 		},
 	});
 }
@@ -20,7 +28,9 @@ const aboutCommand: Command = {
 	register(): ApplicationCommandData {
 		return {
 			name: commandName,
+			nameLocalizations: commandNameLocalizations,
 			description: commandDescription,
+			descriptionLocalizations: commandDescriptionLocalizations,
 		};
 	},
 	async execute(interaction: Interaction): Promise<void> {

--- a/src/commands/bear.ts
+++ b/src/commands/bear.ts
@@ -11,10 +11,26 @@ import type Command from "../commands.js";
 import {Util} from "discord.js";
 import {bears, levels, outfits} from "../bindings.js";
 import {nearest} from "../utils/string.js";
-const commandName: string = "bear";
-const commandDescription: string = "Tells you who is this bear";
-const bearOptionName: string = "bear";
-const bearOptionDescription: string = "Some bear";
+const commandNameLocalizations: {[k: string]: string} = {
+	"en-US": "bear",
+	"fr": "ours",
+};
+const commandName: string = commandNameLocalizations["en-US"];
+const commandDescriptionLocalizations: {[k: string]: string} = {
+	"en-US": "Tells you who is this bear",
+	"fr": "Te dit qui est cet ours",
+};
+const commandDescription: string = commandDescriptionLocalizations["en-US"];
+const bearOptionNameLocalizations: {[k: string]: string} = {
+	"en-US": "bear",
+	"fr": "ours",
+};
+const bearOptionName: string = bearOptionNameLocalizations["en-US"];
+const bearOptionDescriptionLocalizations: {[k: string]: string} = {
+	"en-US": "Some bear",
+	"fr": "Un ours",
+};
+const bearOptionDescription: string = bearOptionDescriptionLocalizations["en-US"];
 const conjunctionFormat: Intl.ListFormat = new Intl.ListFormat("en-US", {
 	style: "long",
 	type: "conjunction",
@@ -22,10 +38,10 @@ const conjunctionFormat: Intl.ListFormat = new Intl.ListFormat("en-US", {
 function computeHelpLocalizations(): {[k in string]: () => string} {
 	return Object.assign(Object.create(null), {
 		"en-US"(): string {
-			return `Type \`/${commandName} ${bearOptionDescription}\` to know who is \`${bearOptionDescription}\``;
+			return `Type \`/${commandNameLocalizations["en-US"]} ${bearOptionDescriptionLocalizations["en-US"]}\` to know who is \`${bearOptionDescriptionLocalizations["en-US"]}\``;
 		},
 		"fr"(): string {
-			return `Tape \`/${commandName} ${bearOptionDescription}\` pour savoir qui est \`${bearOptionDescription}\``;
+			return `Tape \`/${commandNameLocalizations["fr"]} ${bearOptionDescriptionLocalizations["fr"]}\` pour savoir qui est \`${bearOptionDescriptionLocalizations["fr"]}\``;
 		},
 	});
 }
@@ -33,12 +49,16 @@ const bearCommand: Command = {
 	register(): ApplicationCommandData {
 		return {
 			name: commandName,
+			nameLocalizations: commandNameLocalizations,
 			description: commandDescription,
+			descriptionLocalizations: commandDescriptionLocalizations,
 			options: [
 				{
 					type: "STRING",
 					name: bearOptionName,
+					nameLocalizations: bearOptionNameLocalizations,
 					description: bearOptionDescription,
+					descriptionLocalizations: bearOptionDescriptionLocalizations,
 					required: true,
 					autocomplete: true,
 				},

--- a/src/commands/count.ts
+++ b/src/commands/count.ts
@@ -6,15 +6,23 @@ import type {
 } from "discord.js";
 import type Command from "../commands.js";
 import {Util} from "discord.js";
-const commandName: string = "count";
-const commandDescription: string = "Tells you what is the number of members on the server";
+const commandNameLocalizations: {[k: string]: string} = {
+	"en-US": "count",
+	"fr": "décompte",
+};
+const commandName: string = commandNameLocalizations["en-US"];
+const commandDescriptionLocalizations: {[k: string]: string} = {
+	"en-US": "Tells you what is the number of members on the server",
+	"fr": "Te dit quel est le nombre de membres sur le serveur",
+};
+const commandDescription: string = commandDescriptionLocalizations["en-US"];
 function computeHelpLocalizations(): {[k in string]: () => string} {
 	return Object.assign(Object.create(null), {
 		"en-US"(): string {
-			return `Type \`/${commandName}\` to know what is the number of members on the server`;
+			return `Type \`/${commandNameLocalizations["en-US"]}\` to know what is the number of members on the server`;
 		},
 		"fr"(): string {
-			return `Tape \`/${commandName}\` pour savoir quel est le nombre de membres sur le serveur`;
+			return `Tape \`/${commandNameLocalizations["fr"]}\` pour savoir quel est le nombre de membres sur le serveur`;
 		},
 	});
 }
@@ -22,7 +30,9 @@ const countCommand: Command = {
 	register(): ApplicationCommandData {
 		return {
 			name: commandName,
+			nameLocalizations: commandNameLocalizations,
 			description: commandDescription,
+			descriptionLocalizations: commandDescriptionLocalizations,
 		};
 	},
 	async execute(interaction: Interaction): Promise<void> {

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -11,15 +11,23 @@ import * as commands from "../commands.js";
 import * as feeds from "../feeds.js";
 import * as grants from "../grants.js";
 import * as triggers from "../triggers.js";
-const commandName: string = "help";
-const commandDescription: string = "Tells you what are the features I offer";
+const commandNameLocalizations: {[k: string]: string} = {
+	"en-US": "help",
+	"fr": "aide",
+};
+const commandName: string = commandNameLocalizations["en-US"];
+const commandDescriptionLocalizations: {[k: string]: string} = {
+	"en-US": "Tells you what are the features I offer",
+	"fr": "Te dit quelles sont les fonctionnalités que je propose",
+};
+const commandDescription: string = commandDescriptionLocalizations["en-US"];
 function computeHelpLocalizations(): {[k in string]: () => string} {
 	return Object.assign(Object.create(null), {
 		"en-US"(): string {
-			return `Type \`/${commandName}\` to know what are the features I offer`;
+			return `Type \`/${commandNameLocalizations["en-US"]}\` to know what are the features I offer`;
 		},
 		"fr"(): string {
-			return `Tape \`/${commandName}\` pour savoir quelles sont les fonctionnalités que je propose`;
+			return `Tape \`/${commandNameLocalizations["fr"]}\` pour savoir quelles sont les fonctionnalités que je propose`;
 		},
 	});
 }
@@ -27,7 +35,9 @@ const helpCommand: Command = {
 	register(): ApplicationCommandData {
 		return {
 			name: commandName,
+			nameLocalizations: commandNameLocalizations,
 			description: commandDescription,
+			descriptionLocalizations: commandDescriptionLocalizations,
 		};
 	},
 	async execute(interaction: Interaction): Promise<void> {

--- a/src/commands/leaderboard.ts
+++ b/src/commands/leaderboard.ts
@@ -4,8 +4,16 @@ import type {
 	Interaction,
 } from "discord.js";
 import type Command from "../commands.js";
-const commandName: string = "leaderboard";
-const commandDescription: string = "Tells you where to watch community speedruns of the game";
+const commandNameLocalizations: {[k: string]: string} = {
+	"en-US": "leaderboard",
+	"fr": "classement",
+};
+const commandName: string = commandNameLocalizations["en-US"];
+const commandDescriptionLocalizations: {[k: string]: string} = {
+	"en-US": "Tells you where to watch community speedruns of the game",
+	"fr": "Te dit où regarder des speedruns communautaires du jeu",
+};
+const commandDescription: string = commandDescriptionLocalizations["en-US"];
 const leaderboards: string[] = [
 	"[*Full-game leaderboard*](<https://www.speedrun.com/sba>)",
 	"[*Turtle Village leaderboard*](<https://www.speedrun.com/sba/Turtle_Village>)",
@@ -19,10 +27,10 @@ const leaderboards: string[] = [
 function computeHelpLocalizations(): {[k in string]: () => string} {
 	return Object.assign(Object.create(null), {
 		"en-US"(): string {
-			return `Type \`/${commandName}\` to know where to watch community speedruns of the game`;
+			return `Type \`/${commandNameLocalizations["en-US"]}\` to know where to watch community speedruns of the game`;
 		},
 		"fr"(): string {
-			return `Tape \`/${commandName}\` pour savoir où regarder des speedruns communautaires du jeu`;
+			return `Tape \`/${commandNameLocalizations["fr"]}\` pour savoir où regarder des speedruns communautaires du jeu`;
 		},
 	});
 }
@@ -30,7 +38,9 @@ const leaderboardCommand: Command = {
 	register(): ApplicationCommandData {
 		return {
 			name: commandName,
+			nameLocalizations: commandNameLocalizations,
 			description: commandDescription,
+			descriptionLocalizations: commandDescriptionLocalizations,
 		};
 	},
 	async execute(interaction: Interaction): Promise<void> {

--- a/src/commands/mission.ts
+++ b/src/commands/mission.ts
@@ -11,10 +11,26 @@ import type Command from "../commands.js";
 import {Util} from "discord.js";
 import {challenges, levels, missions} from "../bindings.js";
 import {nearest} from "../utils/string.js";
-const commandName: string = "mission";
-const commandDescription: string = "Tells you what is playable in the shop or when it is playable";
-const missionOptionName: string = "mission";
-const missionOptionDescription: string = "Some mission";
+const commandNameLocalizations: {[k: string]: string} = {
+	"en-US": "mission",
+	"fr": "mission",
+};
+const commandName: string = commandNameLocalizations["en-US"];
+const commandDescriptionLocalizations: {[k: string]: string} = {
+	"en-US": "Tells you what is playable in the shop or when it is playable",
+	"fr": "Te dit ce qui est jouable dans la boutique ou quand c'est jouable",
+};
+const commandDescription: string = commandDescriptionLocalizations["en-US"];
+const missionOptionNameLocalizations: {[k: string]: string} = {
+	"en-US": "mission",
+	"fr": "mission",
+};
+const missionOptionName: string = missionOptionNameLocalizations["en-US"];
+const missionOptionDescriptionLocalizations: {[k: string]: string} = {
+	"en-US": "Some mission",
+	"fr": "Une mission",
+};
+const missionOptionDescription: string = missionOptionDescriptionLocalizations["en-US"];
 const dateTimeFormat: Intl.DateTimeFormat = new Intl.DateTimeFormat("en-US", {
 	dateStyle: "long",
 	timeStyle: "short",
@@ -32,10 +48,10 @@ const dayTime: string = timeFormat.format(new Date(36000000));
 function computeHelpLocalizations(): {[k in string]: () => string} {
 	return Object.assign(Object.create(null), {
 		"en-US"(): string {
-			return `Type \`/${commandName}\` to know what is playable in the shop\nType \`/${commandName} ${missionOptionDescription}\` to know when \`${missionOptionDescription}\` is playable in the shop`;
+			return `Type \`/${commandNameLocalizations["en-US"]}\` to know what is playable in the shop\nType \`/${commandNameLocalizations["en-US"]} ${missionOptionDescriptionLocalizations["en-US"]}\` to know when \`${missionOptionDescriptionLocalizations["en-US"]}\` is playable in the shop`;
 		},
 		"fr"(): string {
-			return `Tape \`/${commandName}\` pour savoir ce qui est jouable dans la boutique\nTape \`/${commandName} ${missionOptionDescription}\` pour savoir quand \`${missionOptionDescription}\` est jouable dans la boutique`;
+			return `Tape \`/${commandNameLocalizations["fr"]}\` pour savoir ce qui est jouable dans la boutique\nTape \`/${commandNameLocalizations["fr"]} ${missionOptionDescriptionLocalizations["fr"]}\` pour savoir quand \`${missionOptionDescriptionLocalizations["fr"]}\` est jouable dans la boutique`;
 		},
 	});
 }
@@ -43,12 +59,16 @@ const missionCommand: Command = {
 	register(): ApplicationCommandData {
 		return {
 			name: commandName,
+			nameLocalizations: commandNameLocalizations,
 			description: commandDescription,
+			descriptionLocalizations: commandDescriptionLocalizations,
 			options: [
 				{
 					type: "STRING",
 					name: missionOptionName,
+					nameLocalizations: missionOptionNameLocalizations,
 					description: missionOptionDescription,
+					descriptionLocalizations: missionOptionDescriptionLocalizations,
 					autocomplete: true,
 				},
 			],

--- a/src/commands/outfit.ts
+++ b/src/commands/outfit.ts
@@ -15,10 +15,26 @@ import {nearest} from "../utils/string.js";
 const {
 	SHICKA_SALT: salt = "",
 }: NodeJS.ProcessEnv = process.env;
-const commandName: string = "outfit";
-const commandDescription: string = "Tells you what is for sale in the shop or when it is for sale";
-const outfitOptionName: string = "outfit";
-const outfitOptionDescription: string = "Some outfit";
+const commandNameLocalizations: {[k: string]: string} = {
+	"en-US": "outfit",
+	"fr": "costume",
+};
+const commandName: string = commandNameLocalizations["en-US"];
+const commandDescriptionLocalizations: {[k: string]: string} = {
+	"en-US": "Tells you what is for sale in the shop or when it is for sale",
+	"fr": "Te dit ce qui est en vente dans la boutique ou quand c'est en vente",
+};
+const commandDescription: string = commandDescriptionLocalizations["en-US"];
+const outfitOptionNameLocalizations: {[k: string]: string} = {
+	"en-US": "outfit",
+	"fr": "costume",
+};
+const outfitOptionName: string = outfitOptionNameLocalizations["en-US"];
+const outfitOptionDescriptionLocalizations: {[k: string]: string} = {
+	"en-US": "Some outfit",
+	"fr": "Un costume",
+};
+const outfitOptionDescription: string = outfitOptionDescriptionLocalizations["en-US"];
 const dateTimeFormat: Intl.DateTimeFormat = new Intl.DateTimeFormat("en-US", {
 	dateStyle: "long",
 	timeStyle: "short",
@@ -31,10 +47,10 @@ const conjunctionFormat: Intl.ListFormat = new Intl.ListFormat("en-US", {
 function computeHelpLocalizations(): {[k in string]: () => string} {
 	return Object.assign(Object.create(null), {
 		"en-US"(): string {
-			return `Type \`/${commandName}\` to know what is for sale in the shop\nType \`/${commandName} ${outfitOptionDescription}\` to know when \`${outfitOptionDescription}\` is for sale in the shop`;
+			return `Type \`/${commandNameLocalizations["en-US"]}\` to know what is for sale in the shop\nType \`/${commandNameLocalizations["en-US"]} ${outfitOptionDescriptionLocalizations["en-US"]}\` to know when \`${outfitOptionDescriptionLocalizations["en-US"]}\` is for sale in the shop`;
 		},
 		"fr"(): string {
-			return `Tape \`/${commandName}\` pour savoir ce qui est en vente dans la boutique\nTape \`/${commandName} ${outfitOptionDescription}\` pour savoir quand \`${outfitOptionDescription}\` est en vente dans la boutique`;
+			return `Tape \`/${commandNameLocalizations["fr"]}\` pour savoir ce qui est en vente dans la boutique\nTape \`/${commandNameLocalizations["fr"]} ${outfitOptionDescriptionLocalizations["fr"]}\` pour savoir quand \`${outfitOptionDescriptionLocalizations["fr"]}\` est en vente dans la boutique`;
 		},
 	});
 }
@@ -100,12 +116,16 @@ const outfitCommand: Command = {
 	register(): ApplicationCommandData {
 		return {
 			name: commandName,
+			nameLocalizations: commandNameLocalizations,
 			description: commandDescription,
+			descriptionLocalizations: commandDescriptionLocalizations,
 			options: [
 				{
 					type: "STRING",
 					name: outfitOptionName,
+					nameLocalizations: outfitOptionNameLocalizations,
 					description: outfitOptionDescription,
+					descriptionLocalizations: outfitOptionDescriptionLocalizations,
 					autocomplete: true,
 				},
 			],

--- a/src/commands/raw.ts
+++ b/src/commands/raw.ts
@@ -8,12 +8,36 @@ import type Binding from "../bindings.js";
 import type Command from "../commands.js";
 import {Util} from "discord.js";
 import * as bindings from "../bindings.js";
-const commandName: string = "raw";
-const commandDescription: string = "Tells you what is the datum of this type with this identifier";
-const typeOptionName: string = "type";
-const typeOptionDescription: string = "Some type";
-const identifierOptionName: string = "identifier";
-const identifierOptionDescription: string = "Some identifier";
+const commandNameLocalizations: {[k: string]: string} = {
+	"en-US": "raw",
+	"fr": "brut",
+};
+const commandName: string = commandNameLocalizations["en-US"];
+const commandDescriptionLocalizations: {[k: string]: string} = {
+	"en-US": "Tells you what is the datum of this type with this identifier",
+	"fr": "Te dit quelle est la donnée de ce type avec cet identifiant",
+};
+const commandDescription: string = commandDescriptionLocalizations["en-US"];
+const typeOptionNameLocalizations: {[k: string]: string} = {
+	"en-US": "type",
+	"fr": "costume",
+};
+const typeOptionName: string = typeOptionNameLocalizations["en-US"];
+const typeOptionDescriptionLocalizations: {[k: string]: string} = {
+	"en-US": "Some type",
+	"fr": "Un type",
+};
+const typeOptionDescription: string = typeOptionDescriptionLocalizations["en-US"];
+const identifierOptionNameLocalizations: {[k: string]: string} = {
+	"en-US": "identifier",
+	"fr": "identifiant",
+};
+const identifierOptionName: string = identifierOptionNameLocalizations["en-US"];
+const identifierOptionDescriptionLocalizations: {[k: string]: string} = {
+	"en-US": "Some identifier",
+	"fr": "Un identifiant",
+};
+const identifierOptionDescription: string = identifierOptionDescriptionLocalizations["en-US"];
 const conjunctionFormat: Intl.ListFormat = new Intl.ListFormat("en-US", {
 	style: "long",
 	type: "conjunction",
@@ -21,7 +45,7 @@ const conjunctionFormat: Intl.ListFormat = new Intl.ListFormat("en-US", {
 function computeHelpLocalizations(): {[k in string]: () => string} {
 	return Object.assign(Object.create(null), {
 		"en-US"(): string {
-			return `Type \`/${commandName} ${typeOptionDescription} ${identifierOptionDescription}\` to know what is the datum of \`${typeOptionDescription}\` with \`${identifierOptionDescription}\``;
+			return `Type \`/${commandNameLocalizations["en-US"]} ${typeOptionDescriptionLocalizations["en-US"]} ${identifierOptionDescriptionLocalizations["en-US"]}\` to know what is the datum of \`${typeOptionDescriptionLocalizations["en-US"]}\` with \`${identifierOptionDescriptionLocalizations["en-US"]}\``;
 		},
 		"fr"(): string {
 			return `Tape \`/${commandName} ${typeOptionDescription} ${identifierOptionDescription}\` pour savoir quel est la donnée d'\`${typeOptionDescription}\` avec \`${identifierOptionDescription}\``;
@@ -32,12 +56,16 @@ const rawCommand: Command = {
 	register(): ApplicationCommandData {
 		return {
 			name: commandName,
+			nameLocalizations: commandNameLocalizations,
 			description: commandDescription,
+			descriptionLocalizations: commandDescriptionLocalizations,
 			options: [
 				{
 					type: "STRING",
 					name: typeOptionName,
+					nameLocalizations: typeOptionNameLocalizations,
 					description: typeOptionDescription,
+					descriptionLocalizations: typeOptionDescriptionLocalizations,
 					required: true,
 					choices: Object.keys(bindings).map((bindingName: string): [string, Binding] => {
 						const binding: Binding = bindings[bindingName as keyof typeof bindings] as Binding;

--- a/src/commands/roadmap.ts
+++ b/src/commands/roadmap.ts
@@ -5,15 +5,23 @@ import type {
 	Interaction,
 } from "discord.js";
 import type Command from "../commands.js";
-const commandName: string = "roadmap";
-const commandDescription: string = "Tells you where to check the upcoming milestones of the game";
+const commandNameLocalizations: {[k: string]: string} = {
+	"en-US": "roadmap",
+	"fr": "feuille-de-route",
+};
+const commandName: string = commandNameLocalizations["en-US"];
+const commandDescriptionLocalizations: {[k: string]: string} = {
+	"en-US": "Tells you where to check the upcoming milestones of the game",
+	"fr": "Te dit où consulter les futurs jalons du jeu",
+};
+const commandDescription: string = commandDescriptionLocalizations["en-US"];
 function computeHelpLocalizations(): {[k in string]: () => string} {
 	return Object.assign(Object.create(null), {
 		"en-US"(): string {
-			return `Type \`/${commandName}\` to know where to check the upcoming milestones of the game`;
+			return `Type \`/${commandNameLocalizations["en-US"]}\` to know where to check the upcoming milestones of the game`;
 		},
 		"fr"(): string {
-			return `Tape \`/${commandName}\` pour savoir où consulter les futurs jalons du jeu`;
+			return `Tape \`/${commandNameLocalizations["fr"]}\` pour savoir où consulter les futurs jalons du jeu`;
 		},
 	});
 }
@@ -21,7 +29,9 @@ const roadmapCommand: Command = {
 	register(): ApplicationCommandData {
 		return {
 			name: commandName,
+			nameLocalizations: commandNameLocalizations,
 			description: commandDescription,
+			descriptionLocalizations: commandDescriptionLocalizations,
 		};
 	},
 	async execute(interaction: Interaction): Promise<void> {

--- a/src/commands/store.ts
+++ b/src/commands/store.ts
@@ -4,8 +4,16 @@ import type {
 	Interaction,
 } from "discord.js";
 import type Command from "../commands.js";
-const commandName: string = "store";
-const commandDescription: string = "Tells you where to buy offical products of the game";
+const commandNameLocalizations: {[k: string]: string} = {
+	"en-US": "store",
+	"fr": "magasin",
+};
+const commandName: string = commandNameLocalizations["en-US"];
+const commandDescriptionLocalizations: {[k: string]: string} = {
+	"en-US": "Tells you where to buy offical products of the game",
+	"fr": "Te dit où acheter des produits officiels du jeu",
+};
+const commandDescription: string = commandDescriptionLocalizations["en-US"];
 const stores: string[] = [
 	"[*European store*](<https://superbearadventure.myspreadshop.net/>)",
 	"[*American and Oceanian store*](<https://superbearadventure.myspreadshop.com/>)",
@@ -13,10 +21,10 @@ const stores: string[] = [
 function computeHelpLocalizations(): {[k in string]: () => string} {
 	return Object.assign(Object.create(null), {
 		"en-US"(): string {
-			return `Type \`/${commandName}\` to know where to buy offical products of the game`;
+			return `Type \`/${commandNameLocalizations["en-US"]}\` to know where to buy offical products of the game`;
 		},
 		"fr"(): string {
-			return `Tape \`/${commandName}\` pour savoir où acheter des produits officiels du jeu`;
+			return `Tape \`/${commandNameLocalizations["fr"]}\` pour savoir où acheter des produits officiels du jeu`;
 		},
 	});
 }
@@ -24,7 +32,9 @@ const storeCommand: Command = {
 	register(): ApplicationCommandData {
 		return {
 			name: commandName,
+			nameLocalizations: commandNameLocalizations,
 			description: commandDescription,
+			descriptionLocalizations: commandDescriptionLocalizations,
 		};
 	},
 	async execute(interaction: Interaction): Promise<void> {

--- a/src/commands/tracker.ts
+++ b/src/commands/tracker.ts
@@ -5,8 +5,16 @@ import type {
 	Interaction,
 } from "discord.js";
 import type Command from "../commands.js";
-const commandName: string = "tracker";
-const commandDescription: string = "Tells you where to check known bugs of the game";
+const commandNameLocalizations: {[k: string]: string} = {
+	"en-US": "tracker",
+	"fr": "suivi",
+};
+const commandName: string = commandNameLocalizations["en-US"];
+const commandDescriptionLocalizations: {[k: string]: string} = {
+	"en-US": "Tells you where to check known bugs of the game",
+	"fr": "Te dit où consulter des bogues connus du jeu",
+};
+const commandDescription: string = commandDescriptionLocalizations["en-US"];
 const trackers: string[] = [
 	"[*Current tracker*](<https://github.com/SuperBearAdventure/tracker>)",
 	"[*Former tracker*](<https://trello.com/b/yTojOuqv/super-bear-adventure-bugs>)",
@@ -14,10 +22,10 @@ const trackers: string[] = [
 function computeHelpLocalizations(): {[k in string]: () => string} {
 	return Object.assign(Object.create(null), {
 		"en-US"(): string {
-			return `Type \`/${commandName}\` to know where to check known bugs of the game`;
+			return `Type \`/${commandNameLocalizations["en-US"]}\` to know where to check known bugs of the game`;
 		},
 		"fr"(): string {
-			return `Tape \`/${commandName}\` pour savoir où consulter des bogues connus du jeu`;
+			return `Tape \`/${commandNameLocalizations["fr"]}\` pour savoir où consulter des bogues connus du jeu`;
 		},
 	});
 }
@@ -25,7 +33,9 @@ const trackerCommand: Command = {
 	register(): ApplicationCommandData {
 		return {
 			name: commandName,
+			nameLocalizations: commandNameLocalizations,
 			description: commandDescription,
+			descriptionLocalizations: commandDescriptionLocalizations,
 		};
 	},
 	async execute(interaction: Interaction): Promise<void> {

--- a/src/commands/trailer.ts
+++ b/src/commands/trailer.ts
@@ -4,8 +4,16 @@ import type {
 	Interaction,
 } from "discord.js";
 import type Command from "../commands.js";
-const commandName: string = "trailer";
-const commandDescription: string = "Tells you where to watch official trailers of the game";
+const commandNameLocalizations: {[k: string]: string} = {
+	"en-US": "trailer",
+	"fr": "bande-annonce",
+};
+const commandName: string = commandNameLocalizations["en-US"];
+const commandDescriptionLocalizations: {[k: string]: string} = {
+	"en-US": "Tells you where to watch official trailers of the game",
+	"fr": "Te dit où regarder des bandes-annonces officielles du jeu",
+};
+const commandDescription: string = commandDescriptionLocalizations["en-US"];
 const trailers: string[] = [
 	"[*Main trailer*](<https://www.youtube.com/watch?v=L00uorYTYgE>)",
 	"[*Missions trailer*](<https://www.youtube.com/watch?v=j3vwu0JWIEg>)",
@@ -13,10 +21,10 @@ const trailers: string[] = [
 function computeHelpLocalizations(): {[k in string]: () => string} {
 	return Object.assign(Object.create(null), {
 		"en-US"(): string {
-			return `Type \`/${commandName}\` to know where to watch official trailers of the game`;
+			return `Type \`/${commandNameLocalizations["en-US"]}\` to know where to watch official trailers of the game`;
 		},
 		"fr"(): string {
-			return `Tape \`/${commandName}\` pour savoir où regarder des bandes-annonces officielles du jeu`;
+			return `Tape \`/${commandNameLocalizations["fr"]}\` pour savoir où regarder des bandes-annonces officielles du jeu`;
 		},
 	});
 }
@@ -24,7 +32,9 @@ const trailerCommand: Command = {
 	register(): ApplicationCommandData {
 		return {
 			name: commandName,
+			nameLocalizations: commandNameLocalizations,
 			description: commandDescription,
+			descriptionLocalizations: commandDescriptionLocalizations,
 		};
 	},
 	async execute(interaction: Interaction): Promise<void> {

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -12,8 +12,16 @@ type Data = {
 	version: string,
 	date: number,
 };
-const commandName: string = "update";
-const commandDescription: string = "Tells you what is the latest update of the game";
+const commandNameLocalizations: {[k: string]: string} = {
+	"en-US": "update",
+	"fr": "mise-à-jour",
+};
+const commandName: string = commandNameLocalizations["en-US"];
+const commandDescriptionLocalizations: {[k: string]: string} = {
+	"en-US": "Tells you what is the latest update of the game",
+	"fr": "Te dit quelle est la dernière mise à jour du jeu",
+};
+const commandDescription: string = commandDescriptionLocalizations["en-US"];
 const dateFormat: Intl.DateTimeFormat = new Intl.DateTimeFormat("en-US", {
 	dateStyle: "long",
 	timeZone: "UTC",
@@ -21,10 +29,10 @@ const dateFormat: Intl.DateTimeFormat = new Intl.DateTimeFormat("en-US", {
 function computeHelpLocalizations(): {[k in string]: () => string} {
 	return Object.assign(Object.create(null), {
 		"en-US"(): string {
-			return `Type \`/${commandName}\` to know what is the latest update of the game`;
+			return `Type \`/${commandNameLocalizations["en-US"]}\` to know what is the latest update of the game`;
 		},
 		"fr"(): string {
-			return `Tape \`/${commandName}\` pour savoir quelle est la dernière mise à jour du jeu`;
+			return `Tape \`/${commandNameLocalizations["fr"]}\` pour savoir quelle est la dernière mise à jour du jeu`;
 		},
 	});
 }
@@ -32,7 +40,9 @@ const updateCommand: Command = {
 	register(): ApplicationCommandData {
 		return {
 			name: commandName,
+			nameLocalizations: commandNameLocalizations,
 			description: commandDescription,
+			descriptionLocalizations: commandDescriptionLocalizations,
 		};
 	},
 	async execute(interaction: Interaction): Promise<void> {


### PR DESCRIPTION
This PR is on top of #19.

It adds translations for names and descriptions of application command and application command option. Choices and autocomplete suggestions are not included. Text command names (grants) are also not included.

Note that while the API and Discord.js already support application command localization, the new UI has not reached the stable version of Discord yet so this should not be merged until then.