### PR TITLE
Parses localizations templates instead of using template literals

### DIFF
--- a/src/bindings/bears.json
+++ b/src/bindings/bears.json
@@ -1,7 +1,8 @@
 [
 	{
 		"name": {
-			"en-US": "Barry"
+			"en-US": "Barry",
+			"fr": "Barry"
 		},
 		"gold": 75,
 		"level": 0,
@@ -13,7 +14,8 @@
 	},
 	{
 		"name": {
-			"en-US": "Tommy"
+			"en-US": "Tommy",
+			"fr": "Tommy"
 		},
 		"gold": 20,
 		"level": 0,
@@ -25,7 +27,8 @@
 	},
 	{
 		"name": {
-			"en-US": "Blackbeard"
+			"en-US": "Blackbeard",
+			"fr": "Blackbeard"
 		},
 		"gold": 25,
 		"level": 0,
@@ -37,7 +40,8 @@
 	},
 	{
 		"name": {
-			"en-US": "Stéphane"
+			"en-US": "Stéphane",
+			"fr": "Stéphane"
 		},
 		"gold": 360,
 		"level": 0,
@@ -49,7 +53,8 @@
 	},
 	{
 		"name": {
-			"en-US": "Dr Christopher"
+			"en-US": "Dr Christopher",
+			"fr": "Dr Christopher"
 		},
 		"gold": 25,
 		"level": 0,
@@ -61,7 +66,8 @@
 	},
 	{
 		"name": {
-			"en-US": "Pierre"
+			"en-US": "Pierre",
+			"fr": "Pierre"
 		},
 		"gold": 20,
 		"level": 0,
@@ -73,7 +79,8 @@
 	},
 	{
 		"name": {
-			"en-US": "Bob"
+			"en-US": "Bob",
+			"fr": "Bob"
 		},
 		"gold": 35,
 		"level": 0,
@@ -85,7 +92,8 @@
 	},
 	{
 		"name": {
-			"en-US": "Madeline"
+			"en-US": "Madeline",
+			"fr": "Madeline"
 		},
 		"gold": 30,
 		"level": 0,
@@ -97,7 +105,8 @@
 	},
 	{
 		"name": {
-			"en-US": "Polaris"
+			"en-US": "Polaris",
+			"fr": "Polaris"
 		},
 		"gold": 110,
 		"level": 1,
@@ -109,7 +118,8 @@
 	},
 	{
 		"name": {
-			"en-US": "Flake"
+			"en-US": "Flake",
+			"fr": "Flake"
 		},
 		"gold": 30,
 		"level": 1,
@@ -121,7 +131,8 @@
 	},
 	{
 		"name": {
-			"en-US": "Rodolph"
+			"en-US": "Rodolph",
+			"fr": "Rodolph"
 		},
 		"gold": 25,
 		"level": 1,
@@ -133,7 +144,8 @@
 	},
 	{
 		"name": {
-			"en-US": "Frosty"
+			"en-US": "Frosty",
+			"fr": "Frosty"
 		},
 		"gold": 300,
 		"level": 1,
@@ -145,7 +157,8 @@
 	},
 	{
 		"name": {
-			"en-US": "Alix"
+			"en-US": "Alix",
+			"fr": "Alix"
 		},
 		"gold": 35,
 		"level": 1,
@@ -157,7 +170,8 @@
 	},
 	{
 		"name": {
-			"en-US": "Vladimir"
+			"en-US": "Vladimir",
+			"fr": "Vladimir"
 		},
 		"gold": 15,
 		"level": 1,
@@ -169,7 +183,8 @@
 	},
 	{
 		"name": {
-			"en-US": "Skia"
+			"en-US": "Skia",
+			"fr": "Skia"
 		},
 		"gold": 25,
 		"level": 1,
@@ -181,7 +196,8 @@
 	},
 	{
 		"name": {
-			"en-US": "Jon"
+			"en-US": "Jon",
+			"fr": "Jon"
 		},
 		"gold": 40,
 		"level": 1,
@@ -193,7 +209,8 @@
 	},
 	{
 		"name": {
-			"en-US": "Sand"
+			"en-US": "Sand",
+			"fr": "Sand"
 		},
 		"gold": 115,
 		"level": 2,
@@ -205,7 +222,8 @@
 	},
 	{
 		"name": {
-			"en-US": "Amos"
+			"en-US": "Amos",
+			"fr": "Amos"
 		},
 		"gold": 35,
 		"level": 2,
@@ -217,7 +235,8 @@
 	},
 	{
 		"name": {
-			"en-US": "Alexander"
+			"en-US": "Alexander",
+			"fr": "Alexander"
 		},
 		"gold": 35,
 		"level": 2,
@@ -229,7 +248,8 @@
 	},
 	{
 		"name": {
-			"en-US": "Zephyr"
+			"en-US": "Zephyr",
+			"fr": "Zephyr"
 		},
 		"gold": 570,
 		"level": 2,
@@ -241,7 +261,8 @@
 	},
 	{
 		"name": {
-			"en-US": "Grumble"
+			"en-US": "Grumble",
+			"fr": "Grumble"
 		},
 		"gold": 45,
 		"level": 2,
@@ -253,7 +274,8 @@
 	},
 	{
 		"name": {
-			"en-US": "Numerobis"
+			"en-US": "Numerobis",
+			"fr": "Numerobis"
 		},
 		"gold": 40,
 		"level": 2,
@@ -265,7 +287,8 @@
 	},
 	{
 		"name": {
-			"en-US": "Cleo"
+			"en-US": "Cleo",
+			"fr": "Cleo"
 		},
 		"gold": 25,
 		"level": 2,
@@ -277,7 +300,8 @@
 	},
 	{
 		"name": {
-			"en-US": "Ramses"
+			"en-US": "Ramses",
+			"fr": "Ramses"
 		},
 		"gold": 55,
 		"level": 2,
@@ -289,7 +313,8 @@
 	},
 	{
 		"name": {
-			"en-US": "Viper"
+			"en-US": "Viper",
+			"fr": "Viper"
 		},
 		"gold": 195,
 		"level": 3,
@@ -301,7 +326,8 @@
 	},
 	{
 		"name": {
-			"en-US": "Blossom"
+			"en-US": "Blossom",
+			"fr": "Blossom"
 		},
 		"gold": 105,
 		"level": 3,
@@ -313,7 +339,8 @@
 	},
 	{
 		"name": {
-			"en-US": "Joseph"
+			"en-US": "Joseph",
+			"fr": "Joseph"
 		},
 		"gold": 45,
 		"level": 3,
@@ -325,7 +352,8 @@
 	},
 	{
 		"name": {
-			"en-US": "Toast"
+			"en-US": "Toast",
+			"fr": "Toast"
 		},
 		"gold": 540,
 		"level": 3,
@@ -337,7 +365,8 @@
 	},
 	{
 		"name": {
-			"en-US": "Maya"
+			"en-US": "Maya",
+			"fr": "Maya"
 		},
 		"gold": 35,
 		"level": 3,
@@ -349,7 +378,8 @@
 	},
 	{
 		"name": {
-			"en-US": "Junior"
+			"en-US": "Junior",
+			"fr": "Junior"
 		},
 		"gold": 50,
 		"level": 3,
@@ -361,7 +391,8 @@
 	},
 	{
 		"name": {
-			"en-US": "Claptrap"
+			"en-US": "Claptrap",
+			"fr": "Claptrap"
 		},
 		"gold": 35,
 		"level": 3,
@@ -373,7 +404,8 @@
 	},
 	{
 		"name": {
-			"en-US": "Felix"
+			"en-US": "Felix",
+			"fr": "Felix"
 		},
 		"gold": 40,
 		"level": 3,

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -20,7 +20,7 @@ import updateCommand from "./commands/update.js";
 type Command = {
 	register(): ApplicationCommandData;
 	execute(interaction: Interaction): Promise<void>;
-	describe(interaction: CommandInteraction): Localized<() => string>;
+	describe(interaction: CommandInteraction): Localized<(groups: {}) => string> | null;
 };
 const about: Command = aboutCommand;
 const bear: Command = bearCommand;

--- a/src/commands/about.ts
+++ b/src/commands/about.ts
@@ -5,15 +5,15 @@ import type {
 } from "discord.js";
 import type Command from "../commands.js";
 import type {Localized} from "../utils/string.js";
+import {compileAll, composeAll, localize} from "../utils/string.js";
+type HelpGroups = {
+	commandName: () => string,
+};
 const commandName: string = "about";
 const commandDescription: string = "Tells you where I come from";
-const helpLocalizations: Localized<() => string> = Object.assign(Object.create(null), {
-	"en-US"(): string {
-		return `Type \`/${commandName}\` to know where I come from`;
-	},
-	"fr"(): string {
-		return `Tape \`/${commandName}\` pour savoir d'où je viens`;
-	},
+const helpLocalizations: Localized<(groups: HelpGroups) => string> = compileAll<HelpGroups>({
+	"en-US": "Type `/$<commandName>` to know where I come from",
+	"fr": "Tape `/$<commandName>` pour savoir d'où je viens",
 });
 const aboutCommand: Command = {
 	register(): ApplicationCommandData {
@@ -30,8 +30,14 @@ const aboutCommand: Command = {
 			content: "I am *Shicka*, a bot made by *PolariTOON*, and I am open source!\nMy code is available [there](<https://github.com/SuperBearAdventure/shicka>).",
 		});
 	},
-	describe(interaction: CommandInteraction): Localized<() => string> {
-		return helpLocalizations;
+	describe(interaction: CommandInteraction): Localized<(groups: {}) => string> | null {
+		return composeAll<HelpGroups, {}>(helpLocalizations, localize<HelpGroups>((): HelpGroups => {
+			return {
+				commandName: (): string => {
+					return commandName;
+				},
+			};
+		}));
 	},
 };
 export default aboutCommand;

--- a/src/commands/count.ts
+++ b/src/commands/count.ts
@@ -7,15 +7,15 @@ import type {
 import type Command from "../commands.js";
 import type {Localized} from "../utils/string.js";
 import {Util} from "discord.js";
+import {compileAll, composeAll, localize} from "../utils/string.js";
+type HelpGroups = {
+	commandName: () => string,
+};
 const commandName: string = "count";
 const commandDescription: string = "Tells you what is the number of members on the server";
-const helpLocalizations: Localized<() => string> = Object.assign(Object.create(null), {
-	"en-US"(): string {
-		return `Type \`/${commandName}\` to know what is the number of members on the server`;
-	},
-	"fr"(): string {
-		return `Tape \`/${commandName}\` pour savoir quel est le nombre de membres sur le serveur`;
-	},
+const helpLocalizations: Localized<(groups: HelpGroups) => string> = compileAll({
+	"en-US": "Type `/$<commandName>` to know what is the number of members on the server",
+	"fr": "Tape `/$<commandName>` pour savoir quel est le nombre de membres sur le serveur",
 });
 const countCommand: Command = {
 	register(): ApplicationCommandData {
@@ -37,8 +37,14 @@ const countCommand: Command = {
 			content: `There are ${Util.escapeMarkdown(`${memberCount}`)} members on the official *${Util.escapeMarkdown(name)}* *Discord* server!`,
 		});
 	},
-	describe(interaction: CommandInteraction): Localized<() => string> {
-		return helpLocalizations;
+	describe(interaction: CommandInteraction): Localized<(groups: {}) => string> | null {
+		return composeAll<HelpGroups, {}>(helpLocalizations, localize<HelpGroups>((): HelpGroups => {
+			return {
+				commandName: (): string => {
+					return commandName;
+				},
+			};
+		}));
 	},
 };
 export default countCommand;

--- a/src/commands/leaderboard.ts
+++ b/src/commands/leaderboard.ts
@@ -5,7 +5,10 @@ import type {
 } from "discord.js";
 import type Command from "../commands.js";
 import type {Localized} from "../utils/string.js";
-import {list} from "../utils/string.js";
+import {compileAll, composeAll, list, localize} from "../utils/string.js";
+type HelpGroups = {
+	commandName: () => string,
+};
 const commandName: string = "leaderboard";
 const commandDescription: string = "Tells you where to watch community speedruns of the game";
 const leaderboards: string[] = [
@@ -18,13 +21,9 @@ const leaderboards: string[] = [
 	"[*Races leaderboard*](<https://www.speedrun.com/sbace/Races>)",
 	"[*Category Extensions leaderboard*](<https://www.speedrun.com/sbace>)",
 ];
-const helpLocalizations: Localized<() => string> = Object.assign(Object.create(null), {
-	"en-US"(): string {
-		return `Type \`/${commandName}\` to know where to watch community speedruns of the game`;
-	},
-	"fr"(): string {
-		return `Tape \`/${commandName}\` pour savoir où regarder des speedruns communautaires du jeu`;
-	},
+const helpLocalizations: Localized<(groups: HelpGroups) => string> = compileAll({
+	"en-US": "Type `/$<commandName>` to know where to watch community speedruns of the game",
+	"fr": "Tape `/$<commandName>` pour savoir où regarder des speedruns communautaires du jeu",
 });
 const leaderboardCommand: Command = {
 	register(): ApplicationCommandData {
@@ -42,8 +41,14 @@ const leaderboardCommand: Command = {
 			content: `You can watch community speedruns there:\n${linkList}`,
 		});
 	},
-	describe(interaction: CommandInteraction): Localized<() => string> {
-		return helpLocalizations;
+	describe(interaction: CommandInteraction): Localized<(groups: {}) => string> | null {
+		return composeAll<HelpGroups, {}>(helpLocalizations, localize<HelpGroups>((): HelpGroups => {
+			return {
+				commandName: (): string => {
+					return commandName;
+				},
+			};
+		}));
 	},
 };
 export default leaderboardCommand;

--- a/src/commands/roadmap.ts
+++ b/src/commands/roadmap.ts
@@ -6,15 +6,15 @@ import type {
 } from "discord.js";
 import type Command from "../commands.js";
 import type {Localized} from "../utils/string.js";
+import {compileAll, composeAll, localize} from "../utils/string.js";
+type HelpGroups = {
+	commandName: () => string,
+};
 const commandName: string = "roadmap";
 const commandDescription: string = "Tells you where to check the upcoming milestones of the game";
-const helpLocalizations: Localized<() => string> = Object.assign(Object.create(null), {
-	"en-US"(): string {
-		return `Type \`/${commandName}\` to know where to check the upcoming milestones of the game`;
-	},
-	"fr"(): string {
-		return `Tape \`/${commandName}\` pour savoir où consulter les futurs jalons du jeu`;
-	},
+const helpLocalizations: Localized<(groups: HelpGroups) => string> = compileAll<HelpGroups>({
+	"en-US": "Type `/$<commandName>` to know where to check the upcoming milestones of the game",
+	"fr": "Tape `/$<commandName>` pour savoir où consulter les futurs jalons du jeu",
 });
 const roadmapCommand: Command = {
 	register(): ApplicationCommandData {
@@ -39,8 +39,14 @@ const roadmapCommand: Command = {
 			content: `${intent} check the upcoming milestones of the game [there](<https://trello.com/b/3DPL9CwV/road-to-100>).`,
 		});
 	},
-	describe(interaction: CommandInteraction): Localized<() => string> {
-		return helpLocalizations;
+	describe(interaction: CommandInteraction): Localized<(groups: {}) => string> | null {
+		return composeAll<HelpGroups, {}>(helpLocalizations, localize<HelpGroups>((): HelpGroups => {
+			return {
+				commandName: (): string => {
+					return commandName;
+				},
+			};
+		}));
 	},
 };
 export default roadmapCommand;

--- a/src/commands/store.ts
+++ b/src/commands/store.ts
@@ -5,20 +5,19 @@ import type {
 } from "discord.js";
 import type Command from "../commands.js";
 import type {Localized} from "../utils/string.js";
-import {list} from "../utils/string.js";
+import {compileAll, composeAll, list, localize} from "../utils/string.js";
+type HelpGroups = {
+	commandName: () => string,
+};
 const commandName: string = "store";
 const commandDescription: string = "Tells you where to buy offical products of the game";
 const stores: string[] = [
 	"[*European store*](<https://superbearadventure.myspreadshop.net/>)",
 	"[*American and Oceanian store*](<https://superbearadventure.myspreadshop.com/>)",
 ];
-const helpLocalizations: Localized<() => string> = Object.assign(Object.create(null), {
-	"en-US"(): string {
-		return `Type \`/${commandName}\` to know where to buy offical products of the game`;
-	},
-	"fr"(): string {
-		return `Tape \`/${commandName}\` pour savoir où acheter des produits officiels du jeu`;
-	},
+const helpLocalizations: Localized<(groups: HelpGroups) => string> = compileAll<HelpGroups>({
+	"en-US": "Type `/$<commandName>` to know where to buy offical products of the game",
+	"fr": "Tape `/$<commandName>` pour savoir où acheter des produits officiels du jeu",
 });
 const storeCommand: Command = {
 	register(): ApplicationCommandData {
@@ -36,8 +35,14 @@ const storeCommand: Command = {
 			content: `You can buy official products of the game there:\n${linkList}`,
 		});
 	},
-	describe(interaction: CommandInteraction): Localized<() => string> {
-		return helpLocalizations;
+	describe(interaction: CommandInteraction): Localized<(groups: {}) => string> | null {
+		return composeAll<HelpGroups, {}>(helpLocalizations, localize<HelpGroups>((): HelpGroups => {
+			return {
+				commandName: (): string => {
+					return commandName;
+				},
+			};
+		}));
 	},
 };
 export default storeCommand;

--- a/src/commands/tracker.ts
+++ b/src/commands/tracker.ts
@@ -6,20 +6,19 @@ import type {
 } from "discord.js";
 import type Command from "../commands.js";
 import type {Localized} from "../utils/string.js";
-import {list} from "../utils/string.js";
+import {compileAll, composeAll, list, localize} from "../utils/string.js";
+type HelpGroups = {
+	commandName: () => string,
+};
 const commandName: string = "tracker";
 const commandDescription: string = "Tells you where to check known bugs of the game";
 const trackers: string[] = [
 	"[*Current tracker*](<https://github.com/SuperBearAdventure/tracker>)",
 	"[*Former tracker*](<https://trello.com/b/yTojOuqv/super-bear-adventure-bugs>)",
 ];
-const helpLocalizations: Localized<() => string> = Object.assign(Object.create(null), {
-	"en-US"(): string {
-		return `Type \`/${commandName}\` to know where to check known bugs of the game`;
-	},
-	"fr"(): string {
-		return `Tape \`/${commandName}\` pour savoir où consulter des bogues connus du jeu`;
-	},
+const helpLocalizations: Localized<(groups: HelpGroups) => string> = compileAll<HelpGroups>({
+	"en-US": "Type `/$<commandName>` to know where to check known bugs of the game",
+	"fr": "Tape `/$<commandName>` pour savoir où consulter des bogues connus du jeu",
 });
 const trackerCommand: Command = {
 	register(): ApplicationCommandData {
@@ -45,8 +44,14 @@ const trackerCommand: Command = {
 			content: `${intent} check the known bugs of the game there:\n${linkList}`,
 		});
 	},
-	describe(interaction: CommandInteraction): Localized<() => string> {
-		return helpLocalizations;
+	describe(interaction: CommandInteraction): Localized<(groups: {}) => string> | null {
+		return composeAll<HelpGroups, {}>(helpLocalizations, localize<HelpGroups>((): HelpGroups => {
+			return {
+				commandName: (): string => {
+					return commandName;
+				},
+			};
+		}));
 	},
 };
 export default trackerCommand;

--- a/src/commands/trailer.ts
+++ b/src/commands/trailer.ts
@@ -5,20 +5,19 @@ import type {
 } from "discord.js";
 import type Command from "../commands.js";
 import type {Localized} from "../utils/string.js";
-import {list} from "../utils/string.js";
+import {compileAll, composeAll, list, localize} from "../utils/string.js";
+type HelpGroups = {
+	commandName: () => string,
+};
 const commandName: string = "trailer";
 const commandDescription: string = "Tells you where to watch official trailers of the game";
 const trailers: string[] = [
 	"[*Main trailer*](<https://www.youtube.com/watch?v=L00uorYTYgE>)",
 	"[*Missions trailer*](<https://www.youtube.com/watch?v=j3vwu0JWIEg>)",
 ];
-const helpLocalizations: Localized<() => string> = Object.assign(Object.create(null), {
-	"en-US"(): string {
-		return `Type \`/${commandName}\` to know where to watch official trailers of the game`;
-	},
-	"fr"(): string {
-		return `Tape \`/${commandName}\` pour savoir où regarder des bandes-annonces officielles du jeu`;
-	},
+const helpLocalizations: Localized<(groups: HelpGroups) => string> = compileAll<HelpGroups>({
+	"en-US": "Type `/$<commandName>` to know where to watch official trailers of the game",
+	"fr": "Tape `/$<commandName>` pour savoir où regarder des bandes-annonces officielles du jeu",
 });
 const trailerCommand: Command = {
 	register(): ApplicationCommandData {
@@ -36,8 +35,14 @@ const trailerCommand: Command = {
 			content: `You can watch official trailers of the game there:\n${linkList}`,
 		});
 	},
-	describe(interaction: CommandInteraction): Localized<() => string> {
-		return helpLocalizations;
+	describe(interaction: CommandInteraction): Localized<(groups: {}) => string> | null {
+		return composeAll<HelpGroups, {}>(helpLocalizations, localize<HelpGroups>((): HelpGroups => {
+			return {
+				commandName: (): string => {
+					return commandName;
+				},
+			};
+		}));
 	},
 };
 export default trailerCommand;

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -9,7 +9,10 @@ import type {Localized} from "../utils/string.js";
 import {Util} from "discord.js";
 import {JSDOM} from "jsdom";
 import fetch from "node-fetch";
-import {list} from "../utils/string.js";
+import {compileAll, composeAll, list, localize} from "../utils/string.js";
+type HelpGroups = {
+	commandName: () => string,
+};
 type Data = {
 	version: string,
 	date: number,
@@ -24,13 +27,9 @@ const dateFormat: Intl.DateTimeFormat = new Intl.DateTimeFormat("en-US", {
 	dateStyle: "long",
 	timeZone: "UTC",
 });
-const helpLocalizations: Localized<() => string> = Object.assign(Object.create(null), {
-	"en-US"(): string {
-		return `Type \`/${commandName}\` to know what is the latest update of the game`;
-	},
-	"fr"(): string {
-		return `Tape \`/${commandName}\` pour savoir quelle est la dernière mise à jour du jeu`;
-	},
+const helpLocalizations: Localized<(groups: HelpGroups) => string> = compileAll<HelpGroups>({
+	"en-US": "Type `/$<commandName>` to know what is the latest update of the game",
+	"fr": "Tape `/$<commandName>` pour savoir quelle est la dernière mise à jour du jeu",
 });
 const updateCommand: Command = {
 	register(): ApplicationCommandData {
@@ -100,8 +99,14 @@ const updateCommand: Command = {
 			});
 		}
 	},
-	describe(interaction: CommandInteraction): Localized<() => string> {
-		return helpLocalizations;
+	describe(interaction: CommandInteraction): Localized<(groups: {}) => string> | null {
+		return composeAll<HelpGroups, {}>(helpLocalizations, localize<HelpGroups>((): HelpGroups => {
+			return {
+				commandName: (): string => {
+					return commandName;
+				},
+			};
+		}));
 	},
 };
 export default updateCommand;

--- a/src/feeds.ts
+++ b/src/feeds.ts
@@ -5,7 +5,7 @@ import recordFeed from "./feeds/record.js";
 type Feed = {
 	register(client: Client): Job;
 	execute(start: number, end: number): Promise<string[]>;
-	describe(interaction: CommandInteraction): Localized<() => string>;
+	describe(interaction: CommandInteraction): Localized<(groups: {}) => string> | null;
 };
 export default Feed;
 const record: Feed = recordFeed;

--- a/src/grants.ts
+++ b/src/grants.ts
@@ -4,7 +4,7 @@ import chatGrant from "./grants/chat.js";
 import emojiGrant from "./grants/emoji.js";
 type Grant = {
 	execute(message: Message, parameter: string[], tokens: string[]): Promise<void>;
-	describe(interaction: CommandInteraction): Localized<() => string>;
+	describe(interaction: CommandInteraction): Localized<(groups: {}) => string> | null;
 };
 const chat: Grant = chatGrant;
 const emoji: Grant = emojiGrant;

--- a/src/shicka.ts
+++ b/src/shicka.ts
@@ -42,7 +42,7 @@ const client: Client = new Client({
 	},
 });
 client.once("ready", async (client: Client): Promise<void> => {
-	const menu: ApplicationCommandData[] = Object.keys(commands).map((commandName: string): ApplicationCommandData => {
+	const menu: ApplicationCommandData[] = Object.keys(commands).map<ApplicationCommandData>((commandName: string): ApplicationCommandData => {
 		const command: Command = commands[commandName as keyof typeof commands] as Command;
 		return command.register();
 	});

--- a/src/triggers.ts
+++ b/src/triggers.ts
@@ -6,7 +6,7 @@ import type {Localized} from "./utils/string.js";
 import rule7Trigger from "./triggers/rule7.js";
 type Trigger = {
 	execute(message: Message): Promise<void>;
-	describe(interaction: CommandInteraction): Localized<() => string>;
+	describe(interaction: CommandInteraction): Localized<(groups: {}) => string> | null;
 };
 const rule7: Trigger = rule7Trigger;
 export default Trigger;

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -2,6 +2,7 @@ export type Localized<Type> = {
 	"en-US": Type,
 	"fr": Type,
 };
+const groupsPattern: RegExp = /\$<([$0-9A-Z_a-z]*)>/gsu;
 function editDistance(a: string, b: string, substitution: boolean): number {
 	if (a.length < b.length) {
 		[a, b] = [b, a];
@@ -80,12 +81,55 @@ export function nearest<Type>(search: string, candidates: Type[], count: number,
 	if (li < lj) {
 		results.length = li;
 	}
-	return results.map((result: Item): Type => {
+	return results.map<Type>((result: Item): Type => {
 		return result.candidate;
 	});
 }
 export function list(items: string[]): string {
-	return items.map((item: string): string => {
+	return items.map<string>((item: string): string => {
 		return `\u{2022} ${item}`;
 	}).join("\n");
+}
+function filter<K extends string, T, U extends T>(input: {[k in K]: T}, callback: (value: T, key: K, input: {[k in K]: T}) => value is U): {[k in K]: U} {
+	return Object.assign<{[k in K]: U}, {[k in K]: U}>(Object.create(null), Object.fromEntries<T>(Object.entries<T>(input).filter<[K, U]>((entry: [string, T]): entry is [K, U] => {
+		const [key, value]: [K, T] = entry as [K, T];
+		return callback(value, key, input);
+	})) as {[k in K]: U});
+}
+function map<K extends string, T, U>(input: {[k in K]: T}, callback: (value: T, key: K, input: {[k in K]: T}) => U): {[k in K]: U} {
+	return Object.assign<{[k in K]: U}, {[k in K]: U}>(Object.create(null), Object.fromEntries<U>(Object.entries<T>(input).map<[K, U]>((entry: [string, T]): [K, U] => {
+		const [key, value]: [K, T] = entry as [K, T];
+		return [
+			key,
+			callback(value, key, input),
+		];
+	})) as {[k in K]: U});
+}
+function compile<Groups extends {[k in string]: () => string}>(template: string): (groups: Groups) => string {
+	return (groups: Groups): string => {
+		return template.replaceAll(groupsPattern, ($0: string, $1: string): string => {
+			return groups[$1]() ?? $0;
+		});
+	};
+}
+export function compileAll<Groups extends {[k in string]: () => string}>(templates: Localized<string>): Localized<(groups: Groups) => string> {
+	return map<keyof Localized<unknown>, string, (groups: Groups) => string>(templates, (template: string): (groups: Groups) => string => {
+		return compile<Groups>(template);
+	});
+}
+function compose<InputGroups extends {[k in string]: () => string}, OutputGroups extends {[k in string]: () => string}>(template: (groups: InputGroups & OutputGroups) => string, inputGroups: InputGroups): (outputGroups: OutputGroups) => string {
+	return (outputGroups: OutputGroups): string => {
+		return template({...outputGroups, ...inputGroups});
+	};
+}
+export function composeAll<InputGroups extends {[k in string]: () => string}, OutputGroups extends {[k in string]: () => string}>(templates: Localized<(groups: InputGroups & OutputGroups) => string>, inputGroups: Localized<InputGroups>): Localized<(outputGroups: OutputGroups) => string> {
+	return map<keyof Localized<unknown>, (groups: InputGroups & OutputGroups) => string, (groups: OutputGroups) => string>(templates, (template: (groups: InputGroups & OutputGroups) => string, locale: keyof Localized<unknown>): (groups: OutputGroups) => string => {
+		return compose<InputGroups, OutputGroups>(template, inputGroups[locale]);
+	});
+}
+export function localize<Type>(callback: (locale: keyof Localized<unknown>) => Type): Localized<Type> {
+	return Object.assign(Object.create(null), {
+		"en-US": callback("en-US"),
+		"fr": callback("fr"),
+	});
 }

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -1,6 +1,6 @@
 export type Localized<Type> = {
 	"en-US": Type,
-	[k: string]: Type | undefined,
+	"fr": Type,
 };
 function editDistance(a: string, b: string, substitution: boolean): number {
 	if (a.length < b.length) {


### PR DESCRIPTION
This is a new strategy to localize commands help descriptions.
This will allow to put help localizations in JSON files, and later even every localization for commands.
A side-effect is that languages other than English can not have a partial localization anymore: everything should be localized for languages that are supported.