### PR TITLE
Translates descriptions into French in commands and grants

### DIFF
--- a/src/commands/about.ts
+++ b/src/commands/about.ts
@@ -10,7 +10,11 @@ type HelpGroups = {
 	commandName: () => string,
 };
 const commandName: string = "about";
-const commandDescription: string = "Tells you where I come from";
+const commandDescriptionLocalizations: Localized<string> = {
+	"en-US": "Tells you where I come from",
+	"fr": "Te dit d'où je viens",
+};
+const commandDescription: string = commandDescriptionLocalizations["en-US"];
 const helpLocalizations: Localized<(groups: HelpGroups) => string> = compileAll<HelpGroups>({
 	"en-US": "Type `/$<commandName>` to know where I come from",
 	"fr": "Tape `/$<commandName>` pour savoir d'où je viens",
@@ -20,6 +24,7 @@ const aboutCommand: Command = {
 		return {
 			name: commandName,
 			description: commandDescription,
+			descriptionLocalizations: commandDescriptionLocalizations,
 		};
 	},
 	async execute(interaction: Interaction): Promise<void> {

--- a/src/commands/bear.ts
+++ b/src/commands/bear.ts
@@ -18,9 +18,17 @@ type HelpGroups = {
 	bearOptionDescription: () => string,
 };
 const commandName: string = "bear";
-const commandDescription: string = "Tells you who is this bear";
+const commandDescriptionLocalizations: Localized<string> = {
+	"en-US": "Tells you who is this bear",
+	"fr": "Te dit qui est cet ours",
+};
+const commandDescription: string = commandDescriptionLocalizations["en-US"];
 const bearOptionName: string = "bear";
-const bearOptionDescription: string = "Some bear";
+const bearOptionDescriptionLocalizations: Localized<string> = {
+	"en-US": "Some bear",
+	"fr": "Un ours",
+};
+const bearOptionDescription: string = bearOptionDescriptionLocalizations["en-US"];
 const conjunctionFormat: Intl.ListFormat = new Intl.ListFormat("en-US", {
 	style: "long",
 	type: "conjunction",
@@ -34,11 +42,13 @@ const bearCommand: Command = {
 		return {
 			name: commandName,
 			description: commandDescription,
+			descriptionLocalizations: commandDescriptionLocalizations,
 			options: [
 				((): ApplicationCommandOptionData & {minValue: number, maxValue: number} => ({
 					type: "INTEGER",
 					name: bearOptionName,
 					description: bearOptionDescription,
+					descriptionLocalizations: bearOptionDescriptionLocalizations,
 					required: true,
 					minValue: 0,
 					maxValue: bears.length - 1,
@@ -97,13 +107,13 @@ const bearCommand: Command = {
 		});
 	},
 	describe(interaction: CommandInteraction): Localized<(groups: {}) => string> | null {
-		return composeAll<HelpGroups, {}>(helpLocalizations, localize<HelpGroups>((): HelpGroups => {
+		return composeAll<HelpGroups, {}>(helpLocalizations, localize<HelpGroups>((locale: keyof Localized<unknown>): HelpGroups => {
 			return {
 				commandName: (): string => {
 					return commandName;
 				},
 				bearOptionDescription: (): string => {
-					return bearOptionDescription;
+					return bearOptionDescriptionLocalizations[locale];
 				},
 			};
 		}));

--- a/src/commands/count.ts
+++ b/src/commands/count.ts
@@ -12,7 +12,11 @@ type HelpGroups = {
 	commandName: () => string,
 };
 const commandName: string = "count";
-const commandDescription: string = "Tells you what is the number of members on the server";
+const commandDescriptionLocalizations: Localized<string> = {
+	"en-US": "Tells you what is the number of members on the server",
+	"fr": "Te dit quel est le nombre de membres sur le serveur",
+};
+const commandDescription: string = commandDescriptionLocalizations["en-US"];
 const helpLocalizations: Localized<(groups: HelpGroups) => string> = compileAll({
 	"en-US": "Type `/$<commandName>` to know what is the number of members on the server",
 	"fr": "Tape `/$<commandName>` pour savoir quel est le nombre de membres sur le serveur",
@@ -22,6 +26,7 @@ const countCommand: Command = {
 		return {
 			name: commandName,
 			description: commandDescription,
+			descriptionLocalizations: commandDescriptionLocalizations,
 		};
 	},
 	async execute(interaction: Interaction): Promise<void> {

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -17,7 +17,11 @@ type HelpGroups = {
 	commandName: () => string,
 };
 const commandName: string = "help";
-const commandDescription: string = "Tells you what are the features I offer";
+const commandDescriptionLocalizations: Localized<string> = {
+	"en-US": "Tells you what are the features I offer",
+	"fr": "Te dit quelles sont les fonctionnalités que je propose",
+};
+const commandDescription: string = commandDescriptionLocalizations["en-US"];
 const helpLocalizations: Localized<(groups: HelpGroups) => string> = compileAll<HelpGroups>({
 	"en-US": "Type `/$<commandName>` to know what are the features I offer",
 	"fr": "Tape `/$<commandName>` pour savoir quelles sont les fonctionnalités que je propose",
@@ -27,6 +31,7 @@ const helpCommand: Command = {
 		return {
 			name: commandName,
 			description: commandDescription,
+			descriptionLocalizations: commandDescriptionLocalizations,
 		};
 	},
 	async execute(interaction: Interaction): Promise<void> {

--- a/src/commands/leaderboard.ts
+++ b/src/commands/leaderboard.ts
@@ -10,7 +10,11 @@ type HelpGroups = {
 	commandName: () => string,
 };
 const commandName: string = "leaderboard";
-const commandDescription: string = "Tells you where to watch community speedruns of the game";
+const commandDescriptionLocalizations: Localized<string> = {
+	"en-US": "Tells you where to watch community speedruns of the game",
+	"fr": "Te dit où regarder des speedruns communautaires du jeu",
+};
+const commandDescription: string = commandDescriptionLocalizations["en-US"];
 const leaderboards: string[] = [
 	"[*Full-game leaderboard*](<https://www.speedrun.com/sba>)",
 	"[*Turtle Village leaderboard*](<https://www.speedrun.com/sba/Turtle_Village>)",
@@ -30,6 +34,7 @@ const leaderboardCommand: Command = {
 		return {
 			name: commandName,
 			description: commandDescription,
+			descriptionLocalizations: commandDescriptionLocalizations,
 		};
 	},
 	async execute(interaction: Interaction): Promise<void> {

--- a/src/commands/mission.ts
+++ b/src/commands/mission.ts
@@ -18,9 +18,17 @@ type HelpGroups = {
 	missionOptionDescription: () => string,
 };
 const commandName: string = "mission";
-const commandDescription: string = "Tells you what is playable in the shop or when it is playable";
+const commandDescriptionLocalizations: Localized<string> = {
+	"en-US": "Tells you what is playable in the shop or when it is playable",
+	"fr": "Te dit ce qui est jouable dans la boutique ou quand c'est jouable",
+};
+const commandDescription: string = commandDescriptionLocalizations["en-US"];
 const missionOptionName: string = "mission";
-const missionOptionDescription: string = "Some mission";
+const missionOptionDescriptionLocalizations: Localized<string> = {
+	"en-US": "Some mission",
+	"fr": "Une mission",
+};
+const missionOptionDescription: string = missionOptionDescriptionLocalizations["en-US"];
 const dateTimeFormat: Intl.DateTimeFormat = new Intl.DateTimeFormat("en-US", {
 	dateStyle: "long",
 	timeStyle: "short",
@@ -44,11 +52,13 @@ const missionCommand: Command = {
 		return {
 			name: commandName,
 			description: commandDescription,
+			descriptionLocalizations: commandDescriptionLocalizations,
 			options: [
 				((): ApplicationCommandOptionData & {minValue: number, maxValue: number} => ({
 					type: "INTEGER",
 					name: missionOptionName,
 					description: missionOptionDescription,
+					descriptionLocalizations: missionOptionDescriptionLocalizations,
 					minValue: 0,
 					maxValue: missions.length - 1,
 					autocomplete: true,
@@ -121,13 +131,13 @@ const missionCommand: Command = {
 		});
 	},
 	describe(interaction: CommandInteraction): Localized<(groups: {}) => string> | null {
-		return composeAll<HelpGroups, {}>(helpLocalizations, localize<HelpGroups>((): HelpGroups => {
+		return composeAll<HelpGroups, {}>(helpLocalizations, localize<HelpGroups>((locale: keyof Localized<unknown>): HelpGroups => {
 			return {
 				commandName: (): string => {
 					return commandName;
 				},
 				missionOptionDescription: (): string => {
-					return missionOptionDescription;
+					return missionOptionDescriptionLocalizations[locale];
 				},
 			};
 		}));

--- a/src/commands/outfit.ts
+++ b/src/commands/outfit.ts
@@ -22,9 +22,17 @@ const {
 	SHICKA_SALT: salt = "",
 }: NodeJS.ProcessEnv = process.env;
 const commandName: string = "outfit";
-const commandDescription: string = "Tells you what is for sale in the shop or when it is for sale";
+const commandDescriptionLocalizations: Localized<string> = {
+	"en-US": "Tells you what is for sale in the shop or when it is for sale",
+	"fr": "Te dit ce qui est en vente dans la boutique ou quand c'est en vente",
+};
+const commandDescription: string = commandDescriptionLocalizations["en-US"];
 const outfitOptionName: string = "outfit";
-const outfitOptionDescription: string = "Some outfit";
+const outfitOptionDescriptionLocalizations: Localized<string> = {
+	"en-US": "Some outfit",
+	"fr": "Un costume",
+};
+const outfitOptionDescription: string = outfitOptionDescriptionLocalizations["en-US"];
 const dateTimeFormat: Intl.DateTimeFormat = new Intl.DateTimeFormat("en-US", {
 	dateStyle: "long",
 	timeStyle: "short",
@@ -101,11 +109,13 @@ const outfitCommand: Command = {
 		return {
 			name: commandName,
 			description: commandDescription,
+			descriptionLocalizations: commandDescriptionLocalizations,
 			options: [
 				((): ApplicationCommandOptionData & {minValue: number, maxValue: number} => ({
 					type: "INTEGER",
 					name: outfitOptionName,
 					description: outfitOptionDescription,
+					descriptionLocalizations: outfitOptionDescriptionLocalizations,
 					minValue: 0,
 					maxValue: outfits.length - 1,
 					autocomplete: true,
@@ -226,13 +236,13 @@ const outfitCommand: Command = {
 		});
 	},
 	describe(interaction: CommandInteraction): Localized<(groups: {}) => string> | null {
-		return composeAll<HelpGroups, {}>(helpLocalizations, localize<HelpGroups>((): HelpGroups => {
+		return composeAll<HelpGroups, {}>(helpLocalizations, localize<HelpGroups>((locale: keyof Localized<unknown>): HelpGroups => {
 			return {
 				commandName: (): string => {
 					return commandName;
 				},
 				outfitOptionDescription: (): string => {
-					return outfitOptionDescription;
+					return outfitOptionDescriptionLocalizations[locale];
 				},
 			};
 		}));

--- a/src/commands/raw.ts
+++ b/src/commands/raw.ts
@@ -16,11 +16,23 @@ type HelpGroups = {
 	identifierOptionDescription: () => string,
 };
 const commandName: string = "raw";
-const commandDescription: string = "Tells you what is the datum of this type with this identifier";
+const commandDescriptionLocalizations: Localized<string> = {
+	"en-US": "Tells you what is the datum of this type with this identifier",
+	"fr": "Te dit quelle est la donnée de ce type avec cet identifiant",
+};
+const commandDescription: string = commandDescriptionLocalizations["en-US"];
 const typeOptionName: string = "type";
-const typeOptionDescription: string = "Some type";
+const typeOptionDescriptionLocalizations: Localized<string> = {
+	"en-US": "Some type",
+	"fr": "Un type",
+};
+const typeOptionDescription: string = typeOptionDescriptionLocalizations["en-US"];
 const identifierOptionName: string = "identifier";
-const identifierOptionDescription: string = "Some identifier";
+const identifierOptionDescriptionLocalizations: Localized<string> = {
+	"en-US": "Some identifier",
+	"fr": "Un identifiant",
+};
+const identifierOptionDescription: string = identifierOptionDescriptionLocalizations["en-US"];
 const conjunctionFormat: Intl.ListFormat = new Intl.ListFormat("en-US", {
 	style: "long",
 	type: "conjunction",
@@ -34,11 +46,13 @@ const rawCommand: Command = {
 		return {
 			name: commandName,
 			description: commandDescription,
+			descriptionLocalizations: commandDescriptionLocalizations,
 			options: [
 				{
 					type: "STRING",
 					name: typeOptionName,
 					description: typeOptionDescription,
+					descriptionLocalizations: typeOptionDescriptionLocalizations,
 					required: true,
 					choices: Object.keys(bindings).map<[string, Binding]>((bindingName: string): [string, Binding] => {
 						const binding: Binding = bindings[bindingName as keyof typeof bindings] as Binding;
@@ -93,16 +107,16 @@ const rawCommand: Command = {
 		});
 	},
 	describe(interaction: CommandInteraction): Localized<(groups: {}) => string> | null {
-		return composeAll<HelpGroups, {}>(helpLocalizations, localize<HelpGroups>((): HelpGroups => {
+		return composeAll<HelpGroups, {}>(helpLocalizations, localize<HelpGroups>((locale: keyof Localized<unknown>): HelpGroups => {
 			return {
 				commandName: (): string => {
 					return commandName;
 				},
 				typeOptionDescription: (): string => {
-					return typeOptionDescription;
+					return typeOptionDescriptionLocalizations[locale];
 				},
 				identifierOptionDescription: (): string => {
-					return identifierOptionDescription;
+					return identifierOptionDescriptionLocalizations[locale];
 				},
 			};
 		}));

--- a/src/commands/roadmap.ts
+++ b/src/commands/roadmap.ts
@@ -11,7 +11,11 @@ type HelpGroups = {
 	commandName: () => string,
 };
 const commandName: string = "roadmap";
-const commandDescription: string = "Tells you where to check the upcoming milestones of the game";
+const commandDescriptionLocalizations: Localized<string> = {
+	"en-US": "Tells you where to check the upcoming milestones of the game",
+	"fr": "Te dit où consulter les futurs jalons du jeu",
+};
+const commandDescription: string = commandDescriptionLocalizations["en-US"];
 const helpLocalizations: Localized<(groups: HelpGroups) => string> = compileAll<HelpGroups>({
 	"en-US": "Type `/$<commandName>` to know where to check the upcoming milestones of the game",
 	"fr": "Tape `/$<commandName>` pour savoir où consulter les futurs jalons du jeu",
@@ -21,6 +25,7 @@ const roadmapCommand: Command = {
 		return {
 			name: commandName,
 			description: commandDescription,
+			descriptionLocalizations: commandDescriptionLocalizations,
 		};
 	},
 	async execute(interaction: Interaction): Promise<void> {

--- a/src/commands/store.ts
+++ b/src/commands/store.ts
@@ -10,7 +10,11 @@ type HelpGroups = {
 	commandName: () => string,
 };
 const commandName: string = "store";
-const commandDescription: string = "Tells you where to buy offical products of the game";
+const commandDescriptionLocalizations: Localized<string> = {
+	"en-US": "Tells you where to buy offical products of the game",
+	"fr": "Te dit où acheter des produits officiels du jeu",
+};
+const commandDescription: string = commandDescriptionLocalizations["en-US"];
 const stores: string[] = [
 	"[*European store*](<https://superbearadventure.myspreadshop.net/>)",
 	"[*American and Oceanian store*](<https://superbearadventure.myspreadshop.com/>)",
@@ -24,6 +28,7 @@ const storeCommand: Command = {
 		return {
 			name: commandName,
 			description: commandDescription,
+			descriptionLocalizations: commandDescriptionLocalizations,
 		};
 	},
 	async execute(interaction: Interaction): Promise<void> {

--- a/src/commands/tracker.ts
+++ b/src/commands/tracker.ts
@@ -11,7 +11,11 @@ type HelpGroups = {
 	commandName: () => string,
 };
 const commandName: string = "tracker";
-const commandDescription: string = "Tells you where to check known bugs of the game";
+const commandDescriptionLocalizations: Localized<string> = {
+	"en-US": "Tells you where to check known bugs of the game",
+	"fr": "Te dit où consulter des bogues connus du jeu",
+};
+const commandDescription: string = commandDescriptionLocalizations["en-US"];
 const trackers: string[] = [
 	"[*Current tracker*](<https://github.com/SuperBearAdventure/tracker>)",
 	"[*Former tracker*](<https://trello.com/b/yTojOuqv/super-bear-adventure-bugs>)",
@@ -25,6 +29,7 @@ const trackerCommand: Command = {
 		return {
 			name: commandName,
 			description: commandDescription,
+			descriptionLocalizations: commandDescriptionLocalizations,
 		};
 	},
 	async execute(interaction: Interaction): Promise<void> {

--- a/src/commands/trailer.ts
+++ b/src/commands/trailer.ts
@@ -10,7 +10,11 @@ type HelpGroups = {
 	commandName: () => string,
 };
 const commandName: string = "trailer";
-const commandDescription: string = "Tells you where to watch official trailers of the game";
+const commandDescriptionLocalizations: Localized<string> = {
+	"en-US": "Tells you where to watch official trailers of the game",
+	"fr": "Te dit où regarder des bandes-annonces officielles du jeu",
+};
+const commandDescription: string = commandDescriptionLocalizations["en-US"];
 const trailers: string[] = [
 	"[*Main trailer*](<https://www.youtube.com/watch?v=L00uorYTYgE>)",
 	"[*Missions trailer*](<https://www.youtube.com/watch?v=j3vwu0JWIEg>)",
@@ -24,6 +28,7 @@ const trailerCommand: Command = {
 		return {
 			name: commandName,
 			description: commandDescription,
+			descriptionLocalizations: commandDescriptionLocalizations,
 		};
 	},
 	async execute(interaction: Interaction): Promise<void> {

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -18,7 +18,11 @@ type Data = {
 	date: number,
 };
 const commandName: string = "update";
-const commandDescription: string = "Tells you what is the latest update of the game";
+const commandDescriptionLocalizations: Localized<string> = {
+	"en-US": "Tells you what is the latest update of the game",
+	"fr": "Te dit quelle est la dernière mise à jour du jeu",
+};
+const commandDescription: string = commandDescriptionLocalizations["en-US"];
 const updates: string[] = [
 	"[*Android*](<https://play.google.com/store/apps/details?id=com.Earthkwak.Platformer>)",
 	"[*iOS*](<https://apps.apple.com/app/id1531842415>)",
@@ -36,6 +40,7 @@ const updateCommand: Command = {
 		return {
 			name: commandName,
 			description: commandDescription,
+			descriptionLocalizations: commandDescriptionLocalizations,
 		};
 	},
 	async execute(interaction: Interaction): Promise<void> {

--- a/src/grants/chat.ts
+++ b/src/grants/chat.ts
@@ -16,9 +16,21 @@ type HelpGroups = {
 	messageArgumentDescription: () => string,
 };
 const grantName: string = "chat";
-const messageArgumentDescription: string = "Some message";
-const channelArgumentDescription: string = "Some channel";
-const contentArgumentDescription: string = "Some content";
+const messageArgumentDescriptionLocalizations: Localized<string> = {
+	"en-US": "Some message",
+	"fr": "Un message",
+};
+const messageArgumentDescription: string = messageArgumentDescriptionLocalizations["en-US"];
+const channelArgumentDescriptionLocalizations: Localized<string> = {
+	"en-US": "Some channel",
+	"fr": "Un salon",
+};
+const channelArgumentDescription: string = channelArgumentDescriptionLocalizations["en-US"];
+const contentArgumentDescriptionLocalizations: Localized<string> = {
+	"en-US": "Some content",
+	"fr": "Un contenu",
+};
+const contentArgumentDescription: string = contentArgumentDescriptionLocalizations["en-US"];
 const {source}: RegExp = MessageMentions.CHANNELS_PATTERN;
 const messagePattern: RegExp = /^(?:0|[1-9]\d*)$/;
 const channelPattern: RegExp = new RegExp(`^(?:${source})$`, "");
@@ -158,19 +170,19 @@ const chatGrant: Grant = {
 		if (channel == null || !("name" in channel) || !channels.has(channel.name)) {
 			return null;
 		}
-		return composeAll<HelpGroups, {}>(helpLocalizations, localize<HelpGroups>((): HelpGroups => {
+		return composeAll<HelpGroups, {}>(helpLocalizations, localize<HelpGroups>((locale: keyof Localized<unknown>): HelpGroups => {
 			return {
 				grantName: (): string => {
 					return grantName;
 				},
 				channelArgumentDescription: (): string => {
-					return channelArgumentDescription;
+					return channelArgumentDescriptionLocalizations[locale];
 				},
 				contentArgumentDescription: (): string => {
-					return contentArgumentDescription;
+					return contentArgumentDescriptionLocalizations[locale];
 				},
 				messageArgumentDescription: (): string => {
-					return messageArgumentDescription;
+					return messageArgumentDescriptionLocalizations[locale];
 				},
 			};
 		}));

--- a/src/grants/emoji.ts
+++ b/src/grants/emoji.ts
@@ -25,8 +25,16 @@ const {createCanvas, loadImage}: any = canvas;
 const here: string = import.meta.url;
 const root: string = here.slice(0, here.lastIndexOf("/"));
 const grantName: string = "emoji";
-const baseArgumentDescription: string = "Some base";
-const stylesArgumentDescription: string = "Some styles";
+const baseArgumentDescriptionLocalizations: Localized<string> = {
+	"en-US": "Some base",
+	"fr": "Une base",
+};
+const baseArgumentDescription: string = baseArgumentDescriptionLocalizations["en-US"];
+const stylesArgumentDescriptionLocalizations: Localized<string> = {
+	"en-US": "Some styles",
+	"fr": "Des styles",
+};
+const stylesArgumentDescription: string = stylesArgumentDescriptionLocalizations["en-US"];
 const conjunctionFormat: Intl.ListFormat = new Intl.ListFormat("en-US", {
 	style: "long",
 	type: "conjunction",
@@ -131,16 +139,16 @@ const emojiGrant: Grant = {
 		if (channel == null || !("name" in channel) || !channels.has(channel.name)) {
 			return null;
 		}
-		return composeAll<HelpGroups, {}>(helpLocalizations, localize<HelpGroups>((): HelpGroups => {
+		return composeAll<HelpGroups, {}>(helpLocalizations, localize<HelpGroups>((locale: keyof Localized<unknown>): HelpGroups => {
 			return {
 				grantName: (): string => {
 					return grantName;
 				},
 				baseArgumentDescription: (): string => {
-					return baseArgumentDescription;
+					return baseArgumentDescriptionLocalizations[locale];
 				},
 				stylesArgumentDescription: (): string => {
-					return stylesArgumentDescription;
+					return stylesArgumentDescriptionLocalizations[locale];
 				},
 			};
 		}));


### PR DESCRIPTION
This is extracted from #21, but:
- without translating command names, because it is not clear yet if this is wanted
- with option and argument descriptions translated (not their names)