### PR TITLE
Translates command replies

### DIFF
--- a/src/commands/about.ts
+++ b/src/commands/about.ts
@@ -4,9 +4,9 @@ import type {
 	Interaction,
 } from "discord.js";
 import type Command from "../commands.js";
-import type {Localized} from "../utils/string.js";
+import type {Locale, Localized} from "../utils/string.js";
 import {Util} from "discord.js";
-import {compileAll, composeAll, localize} from "../utils/string.js";
+import {compileAll, composeAll, localize, resolve} from "../utils/string.js";
 type HelpGroups = {
 	commandName: () => string,
 };
@@ -44,6 +44,8 @@ const aboutCommand: Command = {
 		if (!interaction.isCommand()) {
 			return;
 		}
+		const {locale}: Interaction = interaction;
+		const resolvedLocale: Locale = resolve(locale);
 		await interaction.reply({
 			content: replyLocalizations["en-US"]({
 				bot: (): string => {
@@ -56,6 +58,23 @@ const aboutCommand: Command = {
 					return Util.escapeMarkdown(link);
 				},
 			}),
+		});
+		if (resolvedLocale === "en-US") {
+			return;
+		}
+		await interaction.followUp({
+			content: replyLocalizations[resolvedLocale]({
+				bot: (): string => {
+					return Util.escapeMarkdown(bot);
+				},
+				author: (): string => {
+					return Util.escapeMarkdown(author);
+				},
+				link: (): string => {
+					return Util.escapeMarkdown(link);
+				},
+			}),
+			ephemeral: true,
 		});
 	},
 	describe(interaction: CommandInteraction): Localized<(groups: {}) => string> | null {

--- a/src/commands/about.ts
+++ b/src/commands/about.ts
@@ -5,9 +5,15 @@ import type {
 } from "discord.js";
 import type Command from "../commands.js";
 import type {Localized} from "../utils/string.js";
+import {Util} from "discord.js";
 import {compileAll, composeAll, localize} from "../utils/string.js";
 type HelpGroups = {
 	commandName: () => string,
+};
+type ReplyGroups = {
+	bot: () => string,
+	author: () => string,
+	link: () => string,
 };
 const commandName: string = "about";
 const commandDescriptionLocalizations: Localized<string> = {
@@ -15,9 +21,16 @@ const commandDescriptionLocalizations: Localized<string> = {
 	"fr": "Te dit d'où je viens",
 };
 const commandDescription: string = commandDescriptionLocalizations["en-US"];
+const bot: string = "Shicka";
+const author: string = "PolariTOON";
+const link: string = "https://github.com/SuperBearAdventure/shicka";
 const helpLocalizations: Localized<(groups: HelpGroups) => string> = compileAll<HelpGroups>({
 	"en-US": "Type `/$<commandName>` to know where I come from",
 	"fr": "Tape `/$<commandName>` pour savoir d'où je viens",
+});
+const replyLocalizations: Localized<(groups: ReplyGroups) => string> = compileAll<ReplyGroups>({
+	"en-US": "I am *$<bot>*, a bot made by *$<author>*, and I am open source!\nMy code is available [there](<$<link>>).",
+	"fr": "Je suis *$<bot>*, un robot fait par *$<author>*, et je suis open source !\nMon code est disponible [là](<$<link>>).",
 });
 const aboutCommand: Command = {
 	register(): ApplicationCommandData {
@@ -32,7 +45,17 @@ const aboutCommand: Command = {
 			return;
 		}
 		await interaction.reply({
-			content: "I am *Shicka*, a bot made by *PolariTOON*, and I am open source!\nMy code is available [there](<https://github.com/SuperBearAdventure/shicka>).",
+			content: replyLocalizations["en-US"]({
+				bot: (): string => {
+					return Util.escapeMarkdown(bot);
+				},
+				author: (): string => {
+					return Util.escapeMarkdown(author);
+				},
+				link: (): string => {
+					return Util.escapeMarkdown(link);
+				},
+			}),
 		});
 	},
 	describe(interaction: CommandInteraction): Localized<(groups: {}) => string> | null {

--- a/src/commands/bear.ts
+++ b/src/commands/bear.ts
@@ -130,7 +130,8 @@ const bearCommand: Command = {
 		if (!interaction.isCommand()) {
 			return;
 		}
-		const {options}: CommandInteraction = interaction;
+		const {locale, options}: CommandInteraction = interaction;
+		const resolvedLocale: Locale = resolve(locale);
 		const id: number = options.getInteger(bearOptionName, true);
 		const bear: Bear = bears[id];
 		const {gold, name}: Bear = bear;
@@ -204,6 +205,44 @@ const bearCommand: Command = {
 					return Util.escapeMarkdown(noGoalLocalizations["en-US"]({}));
 				},
 			}),
+		});
+		if (resolvedLocale === "en-US") {
+			return;
+		}
+		await interaction.followUp({
+			content: replyLocalizations[resolvedLocale]({
+				name: (): string => {
+					return Util.escapeMarkdown(name[resolvedLocale]);
+				},
+				level: (): string => {
+					return Util.escapeMarkdown(level.name[resolvedLocale]);
+				},
+				outfitNameConjunction: (): string => {
+					if (bearOutfits.length !== 0) {
+						const conjunctionFormat: Intl.ListFormat = new Intl.ListFormat(resolvedLocale, {
+							style: "long",
+							type: "conjunction",
+						});
+						return conjunctionFormat.format(bearOutfits.map<string>((outfit: Outfit): string => {
+							return `*${Util.escapeMarkdown(outfit.name[resolvedLocale])}*`;
+						}));
+					}
+					return Util.escapeMarkdown(noOutfitLocalizations[resolvedLocale]({}));
+				},
+				goalConjunction: (): string => {
+					if (goals.length !== 0) {
+						const conjunctionFormat: Intl.ListFormat = new Intl.ListFormat(resolvedLocale, {
+							style: "long",
+							type: "conjunction",
+						});
+						return conjunctionFormat.format(goals.map<string>((goal: Localized<(groups: {}) => string>): string => {
+							return goal[resolvedLocale]({});
+						}));
+					}
+					return Util.escapeMarkdown(noGoalLocalizations[resolvedLocale]({}));
+				},
+			}),
+			ephemeral: true,
 		});
 	},
 	describe(interaction: CommandInteraction): Localized<(groups: {}) => string> | null {

--- a/src/commands/count.ts
+++ b/src/commands/count.ts
@@ -5,9 +5,9 @@ import type {
 	Interaction,
 } from "discord.js";
 import type Command from "../commands.js";
-import type {Localized} from "../utils/string.js";
+import type {Locale, Localized} from "../utils/string.js";
 import {Util} from "discord.js";
-import {compileAll, composeAll, localize} from "../utils/string.js";
+import {compileAll, composeAll, localize, resolve} from "../utils/string.js";
 type HelpGroups = {
 	commandName: () => string,
 };
@@ -41,7 +41,8 @@ const countCommand: Command = {
 		if (!interaction.isCommand()) {
 			return;
 		}
-		const {guild}: CommandInteraction = interaction;
+		const {guild, locale}: CommandInteraction = interaction;
+		const resolvedLocale: Locale = resolve(locale);
 		if (guild == null) {
 			return;
 		}
@@ -55,6 +56,20 @@ const countCommand: Command = {
 					return Util.escapeMarkdown(name);
 				},
 			}),
+		});
+		if (resolvedLocale === "en-US") {
+			return;
+		}
+		await interaction.followUp({
+			content: replyLocalizations[resolvedLocale]({
+				memberCount: (): string => {
+					return Util.escapeMarkdown(`${memberCount}`);
+				},
+				name: (): string => {
+					return Util.escapeMarkdown(name);
+				},
+			}),
+			ephemeral: true,
 		});
 	},
 	describe(interaction: CommandInteraction): Localized<(groups: {}) => string> | null {

--- a/src/commands/count.ts
+++ b/src/commands/count.ts
@@ -11,15 +11,23 @@ import {compileAll, composeAll, localize} from "../utils/string.js";
 type HelpGroups = {
 	commandName: () => string,
 };
+type ReplyGroups = {
+	memberCount: () => string,
+	name: () => string,
+};
 const commandName: string = "count";
 const commandDescriptionLocalizations: Localized<string> = {
 	"en-US": "Tells you what is the number of members on the server",
 	"fr": "Te dit quel est le nombre de membres sur le serveur",
 };
 const commandDescription: string = commandDescriptionLocalizations["en-US"];
-const helpLocalizations: Localized<(groups: HelpGroups) => string> = compileAll({
+const helpLocalizations: Localized<(groups: HelpGroups) => string> = compileAll<HelpGroups>({
 	"en-US": "Type `/$<commandName>` to know what is the number of members on the server",
 	"fr": "Tape `/$<commandName>` pour savoir quel est le nombre de membres sur le serveur",
+});
+const replyLocalizations: Localized<(groups: ReplyGroups) => string> = compileAll<ReplyGroups>({
+	"en-US": "There are $<memberCount> members on the official *$<name>* *Discord* server!",
+	"fr": "Il y a $<memberCount> membres sur le serveur *Discord* officiel de *$<name>* !",
 });
 const countCommand: Command = {
 	register(): ApplicationCommandData {
@@ -39,7 +47,14 @@ const countCommand: Command = {
 		}
 		const {memberCount, name}: Guild = guild;
 		await interaction.reply({
-			content: `There are ${Util.escapeMarkdown(`${memberCount}`)} members on the official *${Util.escapeMarkdown(name)}* *Discord* server!`,
+			content: replyLocalizations["en-US"]({
+				memberCount: (): string => {
+					return Util.escapeMarkdown(`${memberCount}`);
+				},
+				name: (): string => {
+					return Util.escapeMarkdown(name);
+				},
+			}),
 		});
 	},
 	describe(interaction: CommandInteraction): Localized<(groups: {}) => string> | null {

--- a/src/commands/leaderboard.ts
+++ b/src/commands/leaderboard.ts
@@ -4,8 +4,8 @@ import type {
 	Interaction,
 } from "discord.js";
 import type Command from "../commands.js";
-import type {Localized} from "../utils/string.js";
-import {compileAll, composeAll, list, localize} from "../utils/string.js";
+import type {Locale, Localized} from "../utils/string.js";
+import {compileAll, composeAll, list, localize, resolve} from "../utils/string.js";
 type HelpGroups = {
 	commandName: () => string,
 };
@@ -48,6 +48,8 @@ const leaderboardCommand: Command = {
 		if (!interaction.isCommand()) {
 			return;
 		}
+		const {locale}: CommandInteraction = interaction;
+		const resolvedLocale: Locale = resolve(locale);
 		const linkList: string = list(leaderboards);
 		await interaction.reply({
 			content: replyLocalizations["en-US"]({
@@ -55,6 +57,17 @@ const leaderboardCommand: Command = {
 					return linkList;
 				},
 			}),
+		});
+		if (resolvedLocale === "en-US") {
+			return;
+		}
+		await interaction.followUp({
+			content: replyLocalizations[resolvedLocale]({
+				linkList: (): string => {
+					return linkList;
+				},
+			}),
+			ephemeral: true,
 		});
 	},
 	describe(interaction: CommandInteraction): Localized<(groups: {}) => string> | null {

--- a/src/commands/leaderboard.ts
+++ b/src/commands/leaderboard.ts
@@ -9,6 +9,9 @@ import {compileAll, composeAll, list, localize} from "../utils/string.js";
 type HelpGroups = {
 	commandName: () => string,
 };
+type ReplyGroups = {
+	linkList: () => string,
+};
 const commandName: string = "leaderboard";
 const commandDescriptionLocalizations: Localized<string> = {
 	"en-US": "Tells you where to watch community speedruns of the game",
@@ -25,9 +28,13 @@ const leaderboards: string[] = [
 	"[*Races leaderboard*](<https://www.speedrun.com/sbace/Races>)",
 	"[*Category Extensions leaderboard*](<https://www.speedrun.com/sbace>)",
 ];
-const helpLocalizations: Localized<(groups: HelpGroups) => string> = compileAll({
+const helpLocalizations: Localized<(groups: HelpGroups) => string> = compileAll<HelpGroups>({
 	"en-US": "Type `/$<commandName>` to know where to watch community speedruns of the game",
 	"fr": "Tape `/$<commandName>` pour savoir où regarder des speedruns communautaires du jeu",
+});
+const replyLocalizations: Localized<(groups: ReplyGroups) => string> = compileAll<ReplyGroups>({
+	"en-US": "You can watch community speedruns there:\n$<linkList>",
+	"fr": "Tu peux regarder des speedruns communautaires là :\n$<linkList>",
 });
 const leaderboardCommand: Command = {
 	register(): ApplicationCommandData {
@@ -43,7 +50,11 @@ const leaderboardCommand: Command = {
 		}
 		const linkList: string = list(leaderboards);
 		await interaction.reply({
-			content: `You can watch community speedruns there:\n${linkList}`,
+			content: replyLocalizations["en-US"]({
+				linkList: (): string => {
+					return linkList;
+				},
+			}),
 		});
 	},
 	describe(interaction: CommandInteraction): Localized<(groups: {}) => string> | null {

--- a/src/commands/mission.ts
+++ b/src/commands/mission.ts
@@ -139,7 +139,8 @@ const missionCommand: Command = {
 		if (!interaction.isCommand()) {
 			return;
 		}
-		const {options}: CommandInteraction = interaction;
+		const {locale, options}: CommandInteraction = interaction;
+		const resolvedLocale: Locale = resolve(locale);
 		const missionCount: number = missions.length;
 		const now: number = Math.floor((interaction.createdTimestamp + 7200000) / 86400000);
 		const id: number | null = options.getInteger(missionOptionName);
@@ -187,6 +188,26 @@ const missionCommand: Command = {
 				},
 			}),
 		});
+		if (resolvedLocale === "en-US") {
+			return;
+		}
+		await interaction.followUp({
+			content: bareReplyLocalizations[resolvedLocale]({
+				dayTime: (): string => {
+					const timeFormat: Intl.DateTimeFormat = new Intl.DateTimeFormat(resolvedLocale, {
+						timeStyle: "short",
+						timeZone: "UTC",
+					});
+					return Util.escapeMarkdown(timeFormat.format(dayTime));
+				},
+				scheduleList: (): string => {
+					return list(schedules.map<string>((schedule: Localized<(groups: {}) => string>): string => {
+						return schedule[resolvedLocale]({})
+					}));
+				},
+			}),
+			ephemeral: true,
+		});
 		return;
 		}
 		const mission: Mission = missions[id];
@@ -227,6 +248,25 @@ const missionCommand: Command = {
 					}));
 				},
 			}),
+		});
+		if (resolvedLocale === "en-US") {
+			return;
+		}
+		await interaction.followUp({
+			content: replyLocalizations[resolvedLocale]({
+				challengeName: (): string => {
+					return Util.escapeMarkdown(challenge.name[resolvedLocale]);
+				},
+				levelName: (): string => {
+					return Util.escapeMarkdown(level.name[resolvedLocale]);
+				},
+				scheduleList: (): string => {
+					return list(schedules.map<string>((schedule: Localized<(groups: {}) => string>): string => {
+						return schedule[resolvedLocale]({})
+					}));
+				},
+			}),
+			ephemeral: true,
 		});
 	},
 	describe(interaction: CommandInteraction): Localized<(groups: {}) => string> | null {

--- a/src/commands/outfit.ts
+++ b/src/commands/outfit.ts
@@ -199,7 +199,8 @@ const outfitCommand: Command = {
 		if (!interaction.isCommand()) {
 			return;
 		}
-		const {options}: CommandInteraction = interaction;
+		const {locale, options}: CommandInteraction = interaction;
+		const resolvedLocale: Locale = resolve(locale);
 		const slicesByRarityBySeed: {[k in string]: Outfit[][][]} = Object.create(null);
 		const slicesPerRarity: number = Math.ceil(Math.max(...rarities.map<number>((rarity: Rarity): number => {
 			if (rarity.slots === 0) {
@@ -263,6 +264,19 @@ const outfitCommand: Command = {
 				},
 			}),
 		});
+		if (resolvedLocale === "en-US") {
+			return;
+		}
+		await interaction.followUp({
+			content: bareReplyLocalizations[resolvedLocale]({
+				scheduleList: (): string => {
+					return list(schedules.map<string>((schedule: Localized<(groups: {}) => string>): string => {
+						return schedule[resolvedLocale]({});
+					}));
+				},
+			}),
+			ephemeral: true,
+		});
 		return;
 		}
 		const outfit: Outfit = outfits[id];
@@ -273,6 +287,17 @@ const outfitCommand: Command = {
 						return Util.escapeMarkdown(outfit.name["en-US"]);
 					},
 				}),
+			});
+			if (resolvedLocale === "en-US") {
+				return;
+			}
+			await interaction.followUp({
+				content: noSlotReplyLocalizations[resolvedLocale]({
+					outfitName: (): string => {
+						return Util.escapeMarkdown(outfit.name[resolvedLocale]);
+					},
+				}),
+				ephemeral: true,
 			});
 			return;
 		}
@@ -349,6 +374,34 @@ const outfitCommand: Command = {
 					}));
 				},
 			}),
+		});
+		if (resolvedLocale === "en-US") {
+			return;
+		}
+		await interaction.followUp({
+			content: replyLocalizations[resolvedLocale]({
+				outfitName: (): string => {
+					return Util.escapeMarkdown(outfit.name[resolvedLocale]);
+				},
+				costConjunction: (): string => {
+					if (costs.length !== 0) {
+						const conjunctionFormat: Intl.ListFormat = new Intl.ListFormat(resolvedLocale, {
+							style: "long",
+							type: "conjunction",
+						});
+						return conjunctionFormat.format(costs.map<string>((cost: Localized<(groups: {}) => string>): string => {
+							return cost[resolvedLocale]({});
+						}));
+					}
+					return Util.escapeMarkdown(noCostLocalizations[resolvedLocale]({}));
+				},
+				scheduleList: (): string => {
+					return list(schedules.map<string>((schedule: Localized<(groups: {}) => string>): string => {
+						return schedule[resolvedLocale]({})
+					}));
+				},
+			}),
+			ephemeral: true,
 		});
 	},
 	describe(interaction: CommandInteraction): Localized<(groups: {}) => string> | null {

--- a/src/commands/raw.ts
+++ b/src/commands/raw.ts
@@ -6,10 +6,10 @@ import type {
 } from "discord.js";
 import type Binding from "../bindings.js";
 import type Command from "../commands.js";
-import type {Localized} from "../utils/string.js";
+import type {Locale, Localized} from "../utils/string.js";
 import {Util} from "discord.js";
 import * as bindings from "../bindings.js";
-import {compileAll, composeAll, localize} from "../utils/string.js";
+import {compileAll, composeAll, localize, resolve} from "../utils/string.js";
 type HelpGroups = {
 	commandName: () => string,
 	typeOptionDescription: () => string,
@@ -91,13 +91,14 @@ const rawCommand: Command = {
 		if (!interaction.isCommand()) {
 			return;
 		}
-		const {options}: CommandInteraction = interaction;
+		const {locale, options}: CommandInteraction = interaction;
+		const resolvedLocale: Locale = resolve(locale);
 		const bindingName: string = options.getString(typeOptionName, true);
 		if (!(bindingName in bindings)) {
 			await interaction.reply({
-				content: noTypeReplyLocalizations["en-US"]({
+				content: noTypeReplyLocalizations[resolvedLocale]({
 					typeConjunction: (): string => {
-						const conjunctionFormat: Intl.ListFormat = new Intl.ListFormat("en-US", {
+						const conjunctionFormat: Intl.ListFormat = new Intl.ListFormat(resolvedLocale, {
 							style: "long",
 							type: "conjunction",
 						});
@@ -115,7 +116,7 @@ const rawCommand: Command = {
 		if (identifier < 0 || identifier >= binding.length) {
 			const max: number = binding.length - 1;
 			await interaction.reply({
-				content: noIdentifierReplyLocalizations["en-US"]({
+				content: noIdentifierReplyLocalizations[resolvedLocale]({
 					max: (): string => {
 						return Util.escapeMarkdown(`${max}`);
 					},

--- a/src/commands/roadmap.ts
+++ b/src/commands/roadmap.ts
@@ -6,19 +6,41 @@ import type {
 } from "discord.js";
 import type Command from "../commands.js";
 import type {Localized} from "../utils/string.js";
+import {Util} from "discord.js";
 import {compileAll, composeAll, localize} from "../utils/string.js";
 type HelpGroups = {
 	commandName: () => string,
 };
+type ReplyGroups = {
+	intent: () => string,
+	link: () => string,
+};
+type IntentWithChannelGroups = {
+	channel: () => string,
+};
+type IntentWithoutChannelGroups = {};
 const commandName: string = "roadmap";
 const commandDescriptionLocalizations: Localized<string> = {
 	"en-US": "Tells you where to check the upcoming milestones of the game",
 	"fr": "Te dit où consulter les futurs jalons du jeu",
 };
 const commandDescription: string = commandDescriptionLocalizations["en-US"];
+const link: string = "https://trello.com/b/3DPL9CwV/road-to-100";
 const helpLocalizations: Localized<(groups: HelpGroups) => string> = compileAll<HelpGroups>({
 	"en-US": "Type `/$<commandName>` to know where to check the upcoming milestones of the game",
 	"fr": "Tape `/$<commandName>` pour savoir où consulter les futurs jalons du jeu",
+});
+const replyLocalizations: Localized<(groups: ReplyGroups) => string> = compileAll<ReplyGroups>({
+	"en-US": "$<intent> check upcoming milestones of the game [there](<$<link>>).",
+	"fr": "$<intent> consulter de futurs jalons du jeu [là](<$<link>>).",
+});
+const intentWithChannelLocalizations: Localized<(groups: IntentWithChannelGroups) => string> = compileAll<IntentWithChannelGroups>({
+	"en-US": "Before suggesting an idea in $<channel>, you can",
+	"fr": "Avant de suggérer une idée dans $<channel>, tu peux",
+});
+const intentWithoutChannelLocalizations: Localized<(groups: IntentWithoutChannelGroups) => string> = compileAll<IntentWithoutChannelGroups>({
+	"en-US": "You can",
+	"fr": "Tu peux",
 });
 const roadmapCommand: Command = {
 	register(): ApplicationCommandData {
@@ -39,9 +61,19 @@ const roadmapCommand: Command = {
 		const channel: GuildBasedChannel | undefined = guild.channels.cache.find((channel: GuildBasedChannel): boolean => {
 			return channel.name === "💡│game-suggestions";
 		});
-		const intent: string = channel != null ? `Before suggesting an idea in ${channel},` : "You can";
 		await interaction.reply({
-			content: `${intent} check the upcoming milestones of the game [there](<https://trello.com/b/3DPL9CwV/road-to-100>).`,
+			content: replyLocalizations["en-US"]({
+				intent: (): string => {
+					return channel != null ? intentWithChannelLocalizations["en-US"]({
+						channel: (): string => {
+							return `${channel}`;
+						},
+					}) : intentWithoutChannelLocalizations["en-US"]({});
+				},
+				link: (): string => {
+					return Util.escapeMarkdown(link);
+				},
+			}),
 		});
 	},
 	describe(interaction: CommandInteraction): Localized<(groups: {}) => string> | null {

--- a/src/commands/soundtrack.ts
+++ b/src/commands/soundtrack.ts
@@ -4,8 +4,8 @@ import type {
 	Interaction,
 } from "discord.js";
 import type Command from "../commands.js";
-import type {Localized} from "../utils/string.js";
-import {compileAll, composeAll, list, localize} from "../utils/string.js";
+import type {Locale, Localized} from "../utils/string.js";
+import {compileAll, composeAll, list, localize, resolve} from "../utils/string.js";
 type HelpGroups = {
 	commandName: () => string,
 };
@@ -53,6 +53,8 @@ const soundtrackCommand: Command = {
 		if (!interaction.isCommand()) {
 			return;
 		}
+		const {locale}: Interaction = interaction;
+		const resolvedLocale: Locale = resolve(locale);
 		const linkList: string = list(soundtracks);
 		await interaction.reply({
 			content: replyLocalizations["en-US"]({
@@ -60,6 +62,17 @@ const soundtrackCommand: Command = {
 					return linkList;
 				},
 			}),
+		});
+		if (resolvedLocale === "en-US") {
+			return;
+		}
+		await interaction.followUp({
+			content: replyLocalizations[resolvedLocale]({
+				linkList: (): string => {
+					return linkList;
+				},
+			}),
+			ephemeral: true,
 		});
 	},
 	describe(interaction: CommandInteraction): Localized<(groups: {}) => string> | null {

--- a/src/commands/soundtrack.ts
+++ b/src/commands/soundtrack.ts
@@ -9,6 +9,9 @@ import {compileAll, composeAll, list, localize} from "../utils/string.js";
 type HelpGroups = {
 	commandName: () => string,
 };
+type ReplyGroups = {
+	linkList: () => string,
+};
 const commandName: string = "soundtrack";
 const commandDescriptionLocalizations: Localized<string> = {
 	"en-US": "Tells you where to listen to official music pieces of the game",
@@ -34,6 +37,10 @@ const helpLocalizations: Localized<(groups: HelpGroups) => string> = compileAll<
 	"en-US": "Type `/$<commandName>` to know where to listen to official music pieces of the game",
 	"fr": "Tape `/$<commandName>` pour savoir où écouter des morceaux de musique officiels du jeu",
 });
+const replyLocalizations: Localized<(groups: ReplyGroups) => string> = compileAll<ReplyGroups>({
+	"en-US": "You can listen to official music pieces of the game there:\n$<linkList>",
+	"fr": "Tu peux écouter des morceaux de musique officiels du jeu là :\n$<linkList>",
+});
 const soundtrackCommand: Command = {
 	register(): ApplicationCommandData {
 		return {
@@ -48,7 +55,11 @@ const soundtrackCommand: Command = {
 		}
 		const linkList: string = list(soundtracks);
 		await interaction.reply({
-			content: `You can listen to official music pieces of the game there:\n${linkList}`,
+			content: replyLocalizations["en-US"]({
+				linkList: (): string => {
+					return linkList;
+				},
+			}),
 		});
 	},
 	describe(interaction: CommandInteraction): Localized<(groups: {}) => string> | null {

--- a/src/commands/store.ts
+++ b/src/commands/store.ts
@@ -4,8 +4,8 @@ import type {
 	Interaction,
 } from "discord.js";
 import type Command from "../commands.js";
-import type {Localized} from "../utils/string.js";
-import {compileAll, composeAll, list, localize} from "../utils/string.js";
+import type {Locale, Localized} from "../utils/string.js";
+import {compileAll, composeAll, list, localize, resolve} from "../utils/string.js";
 type HelpGroups = {
 	commandName: () => string,
 };
@@ -42,6 +42,8 @@ const storeCommand: Command = {
 		if (!interaction.isCommand()) {
 			return;
 		}
+		const {locale}: CommandInteraction = interaction;
+		const resolvedLocale: Locale = resolve(locale);
 		const linkList: string = list(stores);
 		await interaction.reply({
 			content: replyLocalizations["en-US"]({
@@ -49,6 +51,17 @@ const storeCommand: Command = {
 					return linkList;
 				},
 			}),
+		});
+		if (resolvedLocale === "en-US") {
+			return;
+		}
+		await interaction.followUp({
+			content: replyLocalizations[resolvedLocale]({
+				linkList: (): string => {
+					return linkList;
+				},
+			}),
+			ephemeral: true,
 		});
 	},
 	describe(interaction: CommandInteraction): Localized<(groups: {}) => string> | null {

--- a/src/commands/store.ts
+++ b/src/commands/store.ts
@@ -9,6 +9,9 @@ import {compileAll, composeAll, list, localize} from "../utils/string.js";
 type HelpGroups = {
 	commandName: () => string,
 };
+type ReplyGroups = {
+	linkList: () => string,
+};
 const commandName: string = "store";
 const commandDescriptionLocalizations: Localized<string> = {
 	"en-US": "Tells you where to buy offical products of the game",
@@ -22,6 +25,10 @@ const stores: string[] = [
 const helpLocalizations: Localized<(groups: HelpGroups) => string> = compileAll<HelpGroups>({
 	"en-US": "Type `/$<commandName>` to know where to buy offical products of the game",
 	"fr": "Tape `/$<commandName>` pour savoir où acheter des produits officiels du jeu",
+});
+const replyLocalizations: Localized<(groups: ReplyGroups) => string> = compileAll<ReplyGroups>({
+	"en-US": "You can buy official products of the game there:\n$<linkList>",
+	"fr": "Tu peux acheter des produits officiels du jeu là :\n$<linkList>",
 });
 const storeCommand: Command = {
 	register(): ApplicationCommandData {
@@ -37,7 +44,11 @@ const storeCommand: Command = {
 		}
 		const linkList: string = list(stores);
 		await interaction.reply({
-			content: `You can buy official products of the game there:\n${linkList}`,
+			content: replyLocalizations["en-US"]({
+				linkList: (): string => {
+					return linkList;
+				},
+			}),
 		});
 	},
 	describe(interaction: CommandInteraction): Localized<(groups: {}) => string> | null {

--- a/src/commands/tracker.ts
+++ b/src/commands/tracker.ts
@@ -10,6 +10,14 @@ import {compileAll, composeAll, list, localize} from "../utils/string.js";
 type HelpGroups = {
 	commandName: () => string,
 };
+type ReplyGroups = {
+	intent: () => string,
+	linkList: () => string,
+};
+type IntentWithChannelGroups = {
+	channel: () => string,
+};
+type IntentWithoutChannelGroups = {};
 const commandName: string = "tracker";
 const commandDescriptionLocalizations: Localized<string> = {
 	"en-US": "Tells you where to check known bugs of the game",
@@ -24,6 +32,18 @@ const helpLocalizations: Localized<(groups: HelpGroups) => string> = compileAll<
 	"en-US": "Type `/$<commandName>` to know where to check known bugs of the game",
 	"fr": "Tape `/$<commandName>` pour savoir où consulter des bogues connus du jeu",
 });
+const replyLocalizations: Localized<(groups: ReplyGroups) => string> = compileAll<ReplyGroups>({
+	"en-US": "$<intent> check the known bugs of the game there:\n$<linkList>",
+	"fr": "$<intent> consulter des bogues connus du jeu là :\n$<linkList>",
+});
+const intentWithChannelLocalizations: Localized<(groups: IntentWithChannelGroups) => string> = compileAll<IntentWithChannelGroups>({
+	"en-US": "Before reporting a bug in $<channel>, you can",
+	"fr": "Avant de rapporter un bogue dans $<channel>, tu peux",
+});
+const intentWithoutChannelLocalizations: Localized<(groups: IntentWithoutChannelGroups) => string> = compileAll<IntentWithoutChannelGroups>({
+	"en-US": "You can",
+	"fr": "Tu peux",
+});
 const trackerCommand: Command = {
 	register(): ApplicationCommandData {
 		return {
@@ -36,7 +56,6 @@ const trackerCommand: Command = {
 		if (!interaction.isCommand()) {
 			return;
 		}
-		const linkList: string = list(trackers);
 		const {guild}: CommandInteraction = interaction;
 		if (guild == null) {
 			return;
@@ -44,9 +63,20 @@ const trackerCommand: Command = {
 		const channel: GuildBasedChannel | undefined = guild.channels.cache.find((channel: GuildBasedChannel): boolean => {
 			return channel.name === "🐛│bug-report";
 		});
-		const intent: string = channel != null ? `Before reporting a bug in ${channel},` : "You can";
+		const linkList: string = list(trackers);
 		await interaction.reply({
-			content: `${intent} check the known bugs of the game there:\n${linkList}`,
+			content: replyLocalizations["en-US"]({
+				intent: (): string => {
+					return channel != null ? intentWithChannelLocalizations["en-US"]({
+						channel: (): string => {
+							return `${channel}`;
+						},
+					}) : intentWithoutChannelLocalizations["en-US"]({});
+				},
+				linkList: (): string => {
+					return linkList;
+				},
+			}),
 		});
 	},
 	describe(interaction: CommandInteraction): Localized<(groups: {}) => string> | null {

--- a/src/commands/trailer.ts
+++ b/src/commands/trailer.ts
@@ -4,8 +4,8 @@ import type {
 	Interaction,
 } from "discord.js";
 import type Command from "../commands.js";
-import type {Localized} from "../utils/string.js";
-import {compileAll, composeAll, list, localize} from "../utils/string.js";
+import type {Locale, Localized} from "../utils/string.js";
+import {compileAll, composeAll, list, localize, resolve} from "../utils/string.js";
 type HelpGroups = {
 	commandName: () => string,
 };
@@ -43,6 +43,8 @@ const trailerCommand: Command = {
 		if (!interaction.isCommand()) {
 			return;
 		}
+		const {locale}: CommandInteraction = interaction;
+		const resolvedLocale: Locale = resolve(locale);
 		const linkList: string = list(trailers);
 		await interaction.reply({
 			content: replyLocalizations["en-US"]({
@@ -50,6 +52,17 @@ const trailerCommand: Command = {
 					return linkList;
 				},
 			}),
+		});
+		if (resolvedLocale === "en-US") {
+			return;
+		}
+		await interaction.followUp({
+			content: replyLocalizations[resolvedLocale]({
+				linkList: (): string => {
+					return linkList;
+				},
+			}),
+			ephemeral: true,
 		});
 	},
 	describe(interaction: CommandInteraction): Localized<(groups: {}) => string> | null {

--- a/src/commands/trailer.ts
+++ b/src/commands/trailer.ts
@@ -9,6 +9,9 @@ import {compileAll, composeAll, list, localize} from "../utils/string.js";
 type HelpGroups = {
 	commandName: () => string,
 };
+type ReplyGroups = {
+	linkList: () => string,
+};
 const commandName: string = "trailer";
 const commandDescriptionLocalizations: Localized<string> = {
 	"en-US": "Tells you where to watch official trailers of the game",
@@ -24,6 +27,10 @@ const helpLocalizations: Localized<(groups: HelpGroups) => string> = compileAll<
 	"en-US": "Type `/$<commandName>` to know where to watch official trailers of the game",
 	"fr": "Tape `/$<commandName>` pour savoir où regarder des bandes-annonces officielles du jeu",
 });
+const replyLocalizations: Localized<(groups: ReplyGroups) => string> = compileAll<ReplyGroups>({
+	"en-US": "You can watch official trailers of the game there:\n$<linkList>",
+	"fr": "Tu peux regarder des bandes-annonces officielles du jeu là :\n$<linkList>",
+});
 const trailerCommand: Command = {
 	register(): ApplicationCommandData {
 		return {
@@ -38,7 +45,11 @@ const trailerCommand: Command = {
 		}
 		const linkList: string = list(trailers);
 		await interaction.reply({
-			content: `You can watch official trailers of the game there:\n${linkList}`,
+			content: replyLocalizations["en-US"]({
+				linkList: (): string => {
+					return linkList;
+				},
+			}),
 		});
 	},
 	describe(interaction: CommandInteraction): Localized<(groups: {}) => string> | null {


### PR DESCRIPTION
This brings a French translation for command replies.

For privacy reasons, the bot always first replies in (American) English, and then in an ephemeral message written in the user locale if supported (there is only French for now).
As ephemeral messages are only visible by the user, this makes sure the user locale does not leak.

I am not very happy with the implementation that feels overly complex and hard to read and also contains a lot of copy-pastes that could be refactored as functions, but the result is good enough.

Anyway, some work is still needed to improve localization, among other things:
- circumvent French's "écriture inclusive" when talking about bears (because people should have the feeling that Shicka is talking, not that she is writing)
- take into account plural rules for coin and token counts (right now, there is a regression that tells "1 tokens" instead of "1 token")
- translate leaderboard, soundtrack, store, tracker and trailer names, where possible
- put sentences in JSON files (that's the whole point of this declarative implementation)
- refactor `keyof Localized<unknown>` as `Locale` (incomplete translation will not be supported)