### PR TITLE
Translates links in command replies

### DIFF
--- a/src/commands/about.ts
+++ b/src/commands/about.ts
@@ -55,7 +55,7 @@ const aboutCommand: Command = {
 					return Util.escapeMarkdown(author);
 				},
 				link: (): string => {
-					return Util.escapeMarkdown(link);
+					return link;
 				},
 			}),
 		});
@@ -71,7 +71,7 @@ const aboutCommand: Command = {
 					return Util.escapeMarkdown(author);
 				},
 				link: (): string => {
-					return Util.escapeMarkdown(link);
+					return link;
 				},
 			}),
 			ephemeral: true,

--- a/src/commands/bear.ts
+++ b/src/commands/bear.ts
@@ -144,7 +144,7 @@ const bearCommand: Command = {
 		});
 		const boss: Localized<string> | null = bear.id % 8 === 0 ? levels[bear.level].boss : null;
 		const coins: number | null = bear.id % 8 === 3 ? levels[bear.level].coins - 25 : 0;
-		const bossGoal: Localized<(groups: {}) => string> | null = boss != null ? composeAll<BossGoalGroups, {}>(bossGoalLocalizations, localize<BossGoalGroups>((locale: keyof Localized<unknown>): BossGoalGroups => {
+		const bossGoal: Localized<(groups: {}) => string> | null = boss != null ? composeAll<BossGoalGroups, {}>(bossGoalLocalizations, localize<BossGoalGroups>((locale: Locale): BossGoalGroups => {
 			return {
 				boss: (): string => {
 					return Util.escapeMarkdown(boss[locale]);
@@ -246,7 +246,7 @@ const bearCommand: Command = {
 		});
 	},
 	describe(interaction: CommandInteraction): Localized<(groups: {}) => string> | null {
-		return composeAll<HelpGroups, {}>(helpLocalizations, localize<HelpGroups>((locale: keyof Localized<unknown>): HelpGroups => {
+		return composeAll<HelpGroups, {}>(helpLocalizations, localize<HelpGroups>((locale: Locale): HelpGroups => {
 			return {
 				commandName: (): string => {
 					return commandName;

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -72,7 +72,7 @@ const helpCommand: Command = {
 		}).filter<Localized<(groups: {}) => string>>((description: Localized<(groups: {}) => string> | null): description is Localized<(groups: {}) => string> => {
 			return description != null;
 		});
-		const features: Localized<(groups: {}) => string[]> = localize<(groups: {}) => string[]>((locale: keyof Localized<unknown>): (groups: {}) => string[] => {
+		const features: Localized<(groups: {}) => string[]> = localize<(groups: {}) => string[]>((locale: Locale): (groups: {}) => string[] => {
 			return (groups: {}): string[] => {
 				return descriptions.map((description: Localized<(groups: {}) => string>): string[] => {
 					return description[locale](groups).split("\n");

--- a/src/commands/mission.ts
+++ b/src/commands/mission.ts
@@ -153,7 +153,7 @@ const missionCommand: Command = {
 			const challenge: Challenge = challenges[mission.challenge];
 			const level: Level = levels[mission.level];
 			const dayDate: Date = new Date(day * 86400000);
-			const schedule: Localized<(groups: {}) => string> = composeAll<BareScheduleGroups, {}>(bareScheduleLocalizations, localize<BareScheduleGroups>((locale: keyof Localized<unknown>): BareScheduleGroups => {
+			const schedule: Localized<(groups: {}) => string> = composeAll<BareScheduleGroups, {}>(bareScheduleLocalizations, localize<BareScheduleGroups>((locale: Locale): BareScheduleGroups => {
 				return {
 					dayDate: (): string => {
 						const dateFormat: Intl.DateTimeFormat = new Intl.DateTimeFormat(locale, {
@@ -217,7 +217,7 @@ const missionCommand: Command = {
 			const seed: number = (day % missionCount + missionCount) % missionCount;
 			if (missions[seed] === mission) {
 				const dayDateTime: Date = new Date(day * 86400000 + 36000000);
-				const schedule: Localized<(groups: {}) => string> = composeAll<ScheduleGroups, {}>(scheduleLocalizations, localize<ScheduleGroups>((locale: keyof Localized<unknown>): ScheduleGroups => {
+				const schedule: Localized<(groups: {}) => string> = composeAll<ScheduleGroups, {}>(scheduleLocalizations, localize<ScheduleGroups>((locale: Locale): ScheduleGroups => {
 					return {
 						dayDateTime: (): string => {
 							const dateTimeFormat: Intl.DateTimeFormat = new Intl.DateTimeFormat(locale, {
@@ -270,7 +270,7 @@ const missionCommand: Command = {
 		});
 	},
 	describe(interaction: CommandInteraction): Localized<(groups: {}) => string> | null {
-		return composeAll<HelpGroups, {}>(helpLocalizations, localize<HelpGroups>((locale: keyof Localized<unknown>): HelpGroups => {
+		return composeAll<HelpGroups, {}>(helpLocalizations, localize<HelpGroups>((locale: Locale): HelpGroups => {
 			return {
 				commandName: (): string => {
 					return commandName;

--- a/src/commands/outfit.ts
+++ b/src/commands/outfit.ts
@@ -232,7 +232,7 @@ const outfitCommand: Command = {
 				return slices[index];
 			}).flat<Outfit[][]>();
 			const dayDateTime: Date = new Date(day * 21600000);
-			const schedule: Localized<(groups: {}) => string> = composeAll<BareScheduleGroups, {}>(bareScheduleLocalizations, localize<BareScheduleGroups>((locale: keyof Localized<unknown>): BareScheduleGroups => {
+			const schedule: Localized<(groups: {}) => string> = composeAll<BareScheduleGroups, {}>(bareScheduleLocalizations, localize<BareScheduleGroups>((locale: Locale): BareScheduleGroups => {
 				return {
 					dayDateTime: (): string => {
 						const dateTimeFormat: Intl.DateTimeFormat = new Intl.DateTimeFormat(locale, {
@@ -317,7 +317,7 @@ const outfitCommand: Command = {
 			const index: number = day - seed * slicesPerRarity;
 			if (slicesByRarity[outfit.rarity][index].includes(outfit)) {
 				const dayDateTime: Date = new Date(day * 21600000);
-				const schedule: Localized<(groups: {}) => string> = composeAll<ScheduleGroups, {}>(scheduleLocalizations, localize<ScheduleGroups>((locale: keyof Localized<unknown>): ScheduleGroups => {
+				const schedule: Localized<(groups: {}) => string> = composeAll<ScheduleGroups, {}>(scheduleLocalizations, localize<ScheduleGroups>((locale: Locale): ScheduleGroups => {
 					return {
 						dayDateTime: (): string => {
 							const dateTimeFormat: Intl.DateTimeFormat = new Intl.DateTimeFormat(locale, {
@@ -405,7 +405,7 @@ const outfitCommand: Command = {
 		});
 	},
 	describe(interaction: CommandInteraction): Localized<(groups: {}) => string> | null {
-		return composeAll<HelpGroups, {}>(helpLocalizations, localize<HelpGroups>((locale: keyof Localized<unknown>): HelpGroups => {
+		return composeAll<HelpGroups, {}>(helpLocalizations, localize<HelpGroups>((locale: Locale): HelpGroups => {
 			return {
 				commandName: (): string => {
 					return commandName;

--- a/src/commands/raw.ts
+++ b/src/commands/raw.ts
@@ -131,7 +131,7 @@ const rawCommand: Command = {
 		});
 	},
 	describe(interaction: CommandInteraction): Localized<(groups: {}) => string> | null {
-		return composeAll<HelpGroups, {}>(helpLocalizations, localize<HelpGroups>((locale: keyof Localized<unknown>): HelpGroups => {
+		return composeAll<HelpGroups, {}>(helpLocalizations, localize<HelpGroups>((locale: Locale): HelpGroups => {
 			return {
 				commandName: (): string => {
 					return commandName;

--- a/src/commands/roadmap.ts
+++ b/src/commands/roadmap.ts
@@ -72,7 +72,7 @@ const roadmapCommand: Command = {
 					}) : intentWithoutChannelLocalizations["en-US"]({});
 				},
 				link: (): string => {
-					return Util.escapeMarkdown(link);
+					return link;
 				},
 			}),
 		});
@@ -89,7 +89,7 @@ const roadmapCommand: Command = {
 					}) : intentWithoutChannelLocalizations[resolvedLocale]({});
 				},
 				link: (): string => {
-					return Util.escapeMarkdown(link);
+					return link;
 				},
 			}),
 			ephemeral: true,

--- a/src/commands/store.ts
+++ b/src/commands/store.ts
@@ -71,7 +71,7 @@ const storeCommand: Command = {
 		const resolvedLocale: Locale = resolve(locale);
 		const links: Localized<(groups: {}) => string>[] = [];
 		for (const item of data) {
-			const link: Localized<(groups: {}) => string> = composeAll<LinkGroups, {}>(linkLocalizations, localize<LinkGroups>((locale: keyof Localized<unknown>): LinkGroups => {
+			const link: Localized<(groups: {}) => string> = composeAll<LinkGroups, {}>(linkLocalizations, localize<LinkGroups>((locale: Locale): LinkGroups => {
 				return {
 					title: (): string => {
 						return Util.escapeMarkdown(item.title[locale]);

--- a/src/commands/store.ts
+++ b/src/commands/store.ts
@@ -5,6 +5,7 @@ import type {
 } from "discord.js";
 import type Command from "../commands.js";
 import type {Locale, Localized} from "../utils/string.js";
+import {Util} from "discord.js";
 import {compileAll, composeAll, list, localize, resolve} from "../utils/string.js";
 type HelpGroups = {
 	commandName: () => string,
@@ -12,15 +13,35 @@ type HelpGroups = {
 type ReplyGroups = {
 	linkList: () => string,
 };
+type LinkGroups = {
+	title: () => string,
+	link: () => string,
+};
+type Data = {
+	title: Localized<string>,
+	link: string,
+};
 const commandName: string = "store";
 const commandDescriptionLocalizations: Localized<string> = {
 	"en-US": "Tells you where to buy offical products of the game",
 	"fr": "Te dit où acheter des produits officiels du jeu",
 };
 const commandDescription: string = commandDescriptionLocalizations["en-US"];
-const stores: string[] = [
-	"[*European store*](<https://superbearadventure.myspreadshop.net/>)",
-	"[*American and Oceanian store*](<https://superbearadventure.myspreadshop.com/>)",
+const data: Data[] = [
+	{
+		title: {
+			"en-US": "European",
+			"fr": "européen",
+		},
+		link: "https://superbearadventure.myspreadshop.net/",
+	},
+	{
+		title: {
+			"en-US": "American and Oceanian",
+			"fr": "américain et océanien",
+		},
+		link: "https://superbearadventure.myspreadshop.com/",
+	},
 ];
 const helpLocalizations: Localized<(groups: HelpGroups) => string> = compileAll<HelpGroups>({
 	"en-US": "Type `/$<commandName>` to know where to buy offical products of the game",
@@ -29,6 +50,10 @@ const helpLocalizations: Localized<(groups: HelpGroups) => string> = compileAll<
 const replyLocalizations: Localized<(groups: ReplyGroups) => string> = compileAll<ReplyGroups>({
 	"en-US": "You can buy official products of the game there:\n$<linkList>",
 	"fr": "Tu peux acheter des produits officiels du jeu là :\n$<linkList>",
+});
+const linkLocalizations: Localized<((groups: LinkGroups) => string)> = compileAll<LinkGroups>({
+	"en-US": "[$<title> store](<$<link>>)",
+	"fr": "[Magasin $<title>](<$<link>>)",
 });
 const storeCommand: Command = {
 	register(): ApplicationCommandData {
@@ -44,11 +69,26 @@ const storeCommand: Command = {
 		}
 		const {locale}: CommandInteraction = interaction;
 		const resolvedLocale: Locale = resolve(locale);
-		const linkList: string = list(stores);
+		const links: Localized<(groups: {}) => string>[] = [];
+		for (const item of data) {
+			const link: Localized<(groups: {}) => string> = composeAll<LinkGroups, {}>(linkLocalizations, localize<LinkGroups>((locale: keyof Localized<unknown>): LinkGroups => {
+				return {
+					title: (): string => {
+						return Util.escapeMarkdown(item.title[locale]);
+					},
+					link: (): string => {
+						return item.link;
+					},
+				};
+			}));
+			links.push(link);
+		}
 		await interaction.reply({
 			content: replyLocalizations["en-US"]({
 				linkList: (): string => {
-					return linkList;
+					return list(links.map<string>((link: Localized<(groups: {}) => string>): string => {
+						return link["en-US"]({});
+					}));
 				},
 			}),
 		});
@@ -58,7 +98,9 @@ const storeCommand: Command = {
 		await interaction.followUp({
 			content: replyLocalizations[resolvedLocale]({
 				linkList: (): string => {
-					return linkList;
+					return list(links.map<string>((link: Localized<(groups: {}) => string>): string => {
+						return link[resolvedLocale]({});
+					}));
 				},
 			}),
 			ephemeral: true,

--- a/src/commands/tracker.ts
+++ b/src/commands/tracker.ts
@@ -91,7 +91,7 @@ const trackerCommand: Command = {
 		});
 		const links: Localized<(groups: {}) => string>[] = [];
 		for (const item of data) {
-			const link: Localized<(groups: {}) => string> = composeAll<LinkGroups, {}>(linkLocalizations, localize<LinkGroups>((locale: keyof Localized<unknown>): LinkGroups => {
+			const link: Localized<(groups: {}) => string> = composeAll<LinkGroups, {}>(linkLocalizations, localize<LinkGroups>((locale: Locale): LinkGroups => {
 				return {
 					title: (): string => {
 						return Util.escapeMarkdown(item.title[locale]);

--- a/src/commands/trailer.ts
+++ b/src/commands/trailer.ts
@@ -5,6 +5,7 @@ import type {
 } from "discord.js";
 import type Command from "../commands.js";
 import type {Locale, Localized} from "../utils/string.js";
+import {Util} from "discord.js";
 import {compileAll, composeAll, list, localize, resolve} from "../utils/string.js";
 type HelpGroups = {
 	commandName: () => string,
@@ -12,16 +13,33 @@ type HelpGroups = {
 type ReplyGroups = {
 	linkList: () => string,
 };
+type LinkGroups = {
+	title: () => string,
+	link: () => string,
+};
+type Data = {
+	title: string,
+	link: string,
+};
 const commandName: string = "trailer";
 const commandDescriptionLocalizations: Localized<string> = {
 	"en-US": "Tells you where to watch official trailers of the game",
 	"fr": "Te dit où regarder des bandes-annonces officielles du jeu",
 };
 const commandDescription: string = commandDescriptionLocalizations["en-US"];
-const trailers: string[] = [
-	"[*Main trailer*](<https://www.youtube.com/watch?v=L00uorYTYgE>)",
-	"[*Missions trailer*](<https://www.youtube.com/watch?v=j3vwu0JWIEg>)",
-	"[*Hive trailer*](<https://www.youtube.com/watch?v=bT0Dj_FQJ1M>)",
+const data: Data[] = [
+	{
+		title: "Main Showcase",
+		link: "https://www.youtube.com/watch?v=L00uorYTYgE",
+	},
+	{
+		title: "Special Mission Update",
+		link: "https://www.youtube.com/watch?v=j3vwu0JWIEg",
+	},
+	{
+		title: "The Hive Update",
+		link: "https://www.youtube.com/watch?v=bT0Dj_FQJ1M",
+	},
 ];
 const helpLocalizations: Localized<(groups: HelpGroups) => string> = compileAll<HelpGroups>({
 	"en-US": "Type `/$<commandName>` to know where to watch official trailers of the game",
@@ -30,6 +48,10 @@ const helpLocalizations: Localized<(groups: HelpGroups) => string> = compileAll<
 const replyLocalizations: Localized<(groups: ReplyGroups) => string> = compileAll<ReplyGroups>({
 	"en-US": "You can watch official trailers of the game there:\n$<linkList>",
 	"fr": "Tu peux regarder des bandes-annonces officielles du jeu là :\n$<linkList>",
+});
+const linkLocalizations: Localized<((groups: LinkGroups) => string)> = compileAll<LinkGroups>({
+	"en-US": "[*$<title>* trailer](<$<link>>)",
+	"fr": "[Bande-annonce *$<title>*](<$<link>>)",
 });
 const trailerCommand: Command = {
 	register(): ApplicationCommandData {
@@ -45,11 +67,26 @@ const trailerCommand: Command = {
 		}
 		const {locale}: CommandInteraction = interaction;
 		const resolvedLocale: Locale = resolve(locale);
-		const linkList: string = list(trailers);
+		const links: Localized<(groups: {}) => string>[] = [];
+		for (const item of data) {
+			const link: Localized<(groups: {}) => string> = composeAll<LinkGroups, {}>(linkLocalizations, localize<LinkGroups>((): LinkGroups => {
+				return {
+					title: (): string => {
+						return Util.escapeMarkdown(item.title);
+					},
+					link: (): string => {
+						return item.link;
+					},
+				};
+			}));
+			links.push(link);
+		}
 		await interaction.reply({
 			content: replyLocalizations["en-US"]({
 				linkList: (): string => {
-					return linkList;
+					return list(links.map<string>((link: Localized<(groups: {}) => string>): string => {
+						return link["en-US"]({});
+					}));
 				},
 			}),
 		});
@@ -59,7 +96,9 @@ const trailerCommand: Command = {
 		await interaction.followUp({
 			content: replyLocalizations[resolvedLocale]({
 				linkList: (): string => {
-					return linkList;
+					return list(links.map<string>((link: Localized<(groups: {}) => string>): string => {
+						return link[resolvedLocale]({});
+					}));
 				},
 			}),
 			ephemeral: true,

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -116,7 +116,7 @@ const updateCommand: Command = {
 			const data: Data[] = [androidData, iosData];
 			const links: Localized<(groups: {}) => string>[] = [];
 			for (const item of data) {
-				const link: Localized<(groups: {}) => string> = composeAll<LinkGroups, {}>(linkLocalizations, localize<LinkGroups>((locale: keyof Localized<unknown>): LinkGroups => {
+				const link: Localized<(groups: {}) => string> = composeAll<LinkGroups, {}>(linkLocalizations, localize<LinkGroups>((locale: Locale): LinkGroups => {
 					return {
 						title: (): string => {
 							return Util.escapeMarkdown(item.title);

--- a/src/grants/chat.ts
+++ b/src/grants/chat.ts
@@ -6,7 +6,7 @@ import type {
 	MessageAttachment,
 } from "discord.js";
 import type Grant from "../grants.js";
-import type {Localized} from "../utils/string.js";
+import type {Locale, Localized} from "../utils/string.js";
 import {MessageMentions} from "discord.js";
 import {compileAll, composeAll, localize} from "../utils/string.js";
 type HelpGroups = {
@@ -170,7 +170,7 @@ const chatGrant: Grant = {
 		if (channel == null || !("name" in channel) || !channels.has(channel.name)) {
 			return null;
 		}
-		return composeAll<HelpGroups, {}>(helpLocalizations, localize<HelpGroups>((locale: keyof Localized<unknown>): HelpGroups => {
+		return composeAll<HelpGroups, {}>(helpLocalizations, localize<HelpGroups>((locale: Locale): HelpGroups => {
 			return {
 				grantName: (): string => {
 					return grantName;

--- a/src/grants/emoji.ts
+++ b/src/grants/emoji.ts
@@ -8,7 +8,7 @@ import type {
 	CanvasRenderingContext2D,
 } from "canvas";
 import type Grant from "../grants.js";
-import type {Localized} from "../utils/string.js";
+import type {Locale, Localized} from "../utils/string.js";
 import {readFile} from "node:fs/promises";
 import {fileURLToPath} from "node:url";
 import canvas from "canvas";
@@ -139,7 +139,7 @@ const emojiGrant: Grant = {
 		if (channel == null || !("name" in channel) || !channels.has(channel.name)) {
 			return null;
 		}
-		return composeAll<HelpGroups, {}>(helpLocalizations, localize<HelpGroups>((locale: keyof Localized<unknown>): HelpGroups => {
+		return composeAll<HelpGroups, {}>(helpLocalizations, localize<HelpGroups>((locale: Locale): HelpGroups => {
 			return {
 				grantName: (): string => {
 					return grantName;

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -113,7 +113,7 @@ function compile<Groups extends {[k in string]: () => string}>(template: string)
 	};
 }
 export function compileAll<Groups extends {[k in string]: () => string}>(templates: Localized<string>): Localized<(groups: Groups) => string> {
-	return map<keyof Localized<unknown>, string, (groups: Groups) => string>(templates, (template: string): (groups: Groups) => string => {
+	return map<Locale, string, (groups: Groups) => string>(templates, (template: string): (groups: Groups) => string => {
 		return compile<Groups>(template);
 	});
 }
@@ -123,14 +123,14 @@ function compose<InputGroups extends {[k in string]: () => string}, OutputGroups
 	};
 }
 export function composeAll<InputGroups extends {[k in string]: () => string}, OutputGroups extends {[k in string]: () => string}>(templates: Localized<(groups: InputGroups & OutputGroups) => string>, inputGroups: Localized<InputGroups>): Localized<(outputGroups: OutputGroups) => string> {
-	return map<keyof Localized<unknown>, (groups: InputGroups & OutputGroups) => string, (groups: OutputGroups) => string>(templates, (template: (groups: InputGroups & OutputGroups) => string, locale: keyof Localized<unknown>): (groups: OutputGroups) => string => {
+	return map<Locale, (groups: InputGroups & OutputGroups) => string, (groups: OutputGroups) => string>(templates, (template: (groups: InputGroups & OutputGroups) => string, locale: Locale): (groups: OutputGroups) => string => {
 		return compose<InputGroups, OutputGroups>(template, inputGroups[locale]);
 	});
 }
 export function resolve(locale: string): Locale {
 	return locale === "fr" ? locale : "en-US";
 }
-export function localize<Type>(callback: (locale: keyof Localized<unknown>) => Type): Localized<Type> {
+export function localize<Type>(callback: (locale: Locale) => Type): Localized<Type> {
 	return Object.assign(Object.create(null), {
 		"en-US": callback("en-US"),
 		"fr": callback("fr"),


### PR DESCRIPTION
This translates leaderboard, soundtrack, store, tracker, trailer and update links into French, where possible.