### PR TITLE
Moves string definitions to dedicated JSON files

### DIFF
--- a/src/bindings/outfits.json
+++ b/src/bindings/outfits.json
@@ -2,7 +2,7 @@
 	{
 		"name": {
 			"en-US": "Default",
-			"fr": "Défault"
+			"fr": "Défaut"
 		},
 		"cost": 0,
 		"part": 0,

--- a/src/bindings/parts.json
+++ b/src/bindings/parts.json
@@ -13,8 +13,8 @@
 	},
 	{
 		"name": {
-			"en-US": "Skin",
-			"fr": "Peau"
+			"en-US": "Bear",
+			"fr": "Ours"
 		}
 	},
 	{

--- a/src/bindings/rarities.json
+++ b/src/bindings/rarities.json
@@ -61,8 +61,8 @@
 	},
 	{
 		"name": {
-			"en-US": "Story",
-			"fr": "Histoire"
+			"en-US": "Maybee",
+			"fr": "Isabeille"
 		},
 		"cost": 0,
 		"payoff": 0,

--- a/src/commands/about.ts
+++ b/src/commands/about.ts
@@ -4,40 +4,32 @@ import type {
 	Interaction,
 } from "discord.js";
 import type Command from "../commands.js";
+import type {About as AboutCompilation} from "../compilations.js";
+import type {About as AboutDefinition} from "../definitions.js";
+import type {About as AboutDependency} from "../dependencies.js";
 import type {Locale, Localized} from "../utils/string.js";
 import {Util} from "discord.js";
-import {compileAll, composeAll, localize, resolve} from "../utils/string.js";
-type HelpGroups = {
-	commandName: () => string,
-};
-type ReplyGroups = {
-	bot: () => string,
-	author: () => string,
-	link: () => string,
-};
-const commandName: string = "about";
-const commandDescriptionLocalizations: Localized<string> = {
-	"en-US": "Tells you where I come from",
-	"fr": "Te dit d'où je viens",
-};
-const commandDescription: string = commandDescriptionLocalizations["en-US"];
+import {about as aboutCompilation} from "../compilations.js";
+import {about as aboutDefinition} from "../definitions.js";
+import {composeAll, localize, resolve} from "../utils/string.js";
+type HelpGroups = AboutDependency["help"];
+const {
+	commandName,
+	commandDescription,
+}: AboutDefinition = aboutDefinition;
+const {
+	help: helpLocalizations,
+	reply: replyLocalizations,
+}: AboutCompilation = aboutCompilation;
 const bot: string = "Shicka";
 const author: string = "PolariTOON";
 const link: string = "https://github.com/SuperBearAdventure/shicka";
-const helpLocalizations: Localized<(groups: HelpGroups) => string> = compileAll<HelpGroups>({
-	"en-US": "Type `/$<commandName>` to know where I come from",
-	"fr": "Tape `/$<commandName>` pour savoir d'où je viens",
-});
-const replyLocalizations: Localized<(groups: ReplyGroups) => string> = compileAll<ReplyGroups>({
-	"en-US": "I am *$<bot>*, a bot made by *$<author>*, and I am open source!\nMy code is available [there](<$<link>>).",
-	"fr": "Je suis *$<bot>*, un robot fait par *$<author>*, et je suis open source !\nMon code est disponible [là](<$<link>>).",
-});
 const aboutCommand: Command = {
 	register(): ApplicationCommandData {
 		return {
 			name: commandName,
-			description: commandDescription,
-			descriptionLocalizations: commandDescriptionLocalizations,
+			description: commandDescription["en-US"],
+			descriptionLocalizations: commandDescription,
 		};
 	},
 	async execute(interaction: Interaction): Promise<void> {

--- a/src/commands/bear.ts
+++ b/src/commands/bear.ts
@@ -9,91 +9,48 @@ import type {
 } from "discord.js";
 import type {Bear, Level, Outfit} from "../bindings.js";
 import type Command from "../commands.js";
+import type {Bear as BearCompilation} from "../compilations.js";
+import type {Bear as BearDefinition} from "../definitions.js";
+import type {Bear as BearDependency} from "../dependencies.js";
 import type {Locale, Localized} from "../utils/string.js";
 import {Util} from "discord.js";
 import {bears, levels, outfits} from "../bindings.js";
-import {compileAll, composeAll, localize, nearest, resolve} from "../utils/string.js";
-type HelpGroups = {
-	commandName: () => string,
-	bearOptionDescription: () => string,
-};
-type ReplyGroups = {
-	name: () => string,
-	level: () => string,
-	outfitNameConjunction: () => string,
-	goalConjunction: () => string,
-};
-type NoOutfitGroups = {};
-type BossGoalGroups = {
-	boss: () => string,
-};
-type CoinsGoalGroups = {
-	coins: () => string,
-};
-type TimeGoalGroups = {
-	time: () => string,
-};
-type NoGoalGroups = {};
-const commandName: string = "bear";
-const commandDescriptionLocalizations: Localized<string> = {
-	"en-US": "Tells you who is this bear",
-	"fr": "Te dit qui est cet ours",
-};
-const commandDescription: string = commandDescriptionLocalizations["en-US"];
-const bearOptionName: string = "bear";
-const bearOptionDescriptionLocalizations: Localized<string> = {
-	"en-US": "Some bear",
-	"fr": "Un ours",
-};
-const bearOptionDescription: string = bearOptionDescriptionLocalizations["en-US"];
-const helpLocalizations: Localized<(groups: HelpGroups) => string> = compileAll<HelpGroups>({
-	"en-US": "Type `/$<commandName> $<bearOptionDescription>` to know who is `$<bearOptionDescription>`",
-	"fr": "Tape `/$<commandName> $<bearOptionDescription>` pour savoir qui est `$<bearOptionDescription>`",
-});
-const replyLocalizations: Localized<(groups: ReplyGroups) => string> = compileAll<ReplyGroups>({
-	"en-US": "**$<name>** has been imprisoned in **$<level>** and is wearing $<outfitNameConjunction>.\n$<goalConjunction>!",
-	"fr": "**$<name>** a été emprisonné·e dans **$<level>** et porte $<outfitNameConjunction>.\n$<goalConjunction> !",
-});
-const noOutfitLocalizations: Localized<(groups: NoOutfitGroups) => string> = compileAll<NoOutfitGroups>({
-	"en-US": "the bare minimum",
-	"fr": "le plus simple appareil",
-});
-const bossGoalLocalizations: Localized<(groups: BossGoalGroups) => string> = compileAll<BossGoalGroups>({
-	"en-US": "Beat **$<boss>**",
-	"fr": "Bats **$<boss>**",
-});
-const coinsWithBossGoalLocalizations: Localized<(groups: CoinsGoalGroups) => string> = compileAll<CoinsGoalGroups>({
-	"en-US": "collect **$<coins> coins**",
-	"fr": "collecte **$<coins> pièces**",
-});
-const coinsWithoutBossGoalLocalizations: Localized<(groups: CoinsGoalGroups) => string> = compileAll<CoinsGoalGroups>({
-	"en-US": "Collect **$<coins> coins**",
-	"fr": "Collecte **$<coins> pièces**",
-});
-const timeWithBossOrCoinsGoalLocalizations: Localized<(groups: TimeGoalGroups) => string> = compileAll<TimeGoalGroups>({
-	"en-US": "unlock the cage in less than **$<time>** to beat the gold time",
-	"fr": "déverrouille la cage en moins de **$<time>** pour battre le temps d'or",
-});
-const timeWithoutBossAndCoinsGoalLocalizations: Localized<(groups: TimeGoalGroups) => string> = compileAll<TimeGoalGroups>({
-	"en-US": "Unlock the cage in less than **$<time>** to beat the gold time",
-	"fr": "Déverrouille la cage en moins de **$<time>** pour battre le temps d'or",
-});
-const noGoalLocalizations: Localized<(groups: NoGoalGroups) => string> = compileAll<NoGoalGroups>({
-	"en-US": "Let's go",
-	"fr": "En route",
-});
+import {bear as bearCompilation} from "../compilations.js";
+import {bear as bearDefinition} from "../definitions.js";
+import {composeAll, localize, nearest, resolve} from "../utils/string.js";
+type HelpGroups = BearDependency["help"];
+type BossGoalGroups = BearDependency["bossGoal"];
+type CoinsGoalGroups = BearDependency["coinsGoal"];
+type TimeGoalGroups = BearDependency["timeGoal"];
+const {
+	commandName,
+	commandDescription,
+	bearOptionName,
+	bearOptionDescription,
+}: BearDefinition = bearDefinition;
+const {
+	help: helpLocalizations,
+	reply: replyLocalizations,
+	noOutfit: noOutfitLocalizations,
+	bossGoal: bossGoalLocalizations,
+	coinsWithBossGoal: coinsWithBossGoalLocalizations,
+	coinsWithoutBossGoal: coinsWithoutBossGoalLocalizations,
+	timeWithBossOrCoinsGoal: timeWithBossOrCoinsGoalLocalizations,
+	timeWithoutBossAndCoinsGoal: timeWithoutBossAndCoinsGoalLocalizations,
+	noGoal: noGoalLocalizations,
+}: BearCompilation = bearCompilation;
 const bearCommand: Command = {
 	register(): ApplicationCommandData {
 		return {
 			name: commandName,
-			description: commandDescription,
-			descriptionLocalizations: commandDescriptionLocalizations,
+			description: commandDescription["en-US"],
+			descriptionLocalizations: commandDescription,
 			options: [
 				((): ApplicationCommandOptionData & {minValue: number, maxValue: number} => ({
 					type: "INTEGER",
 					name: bearOptionName,
-					description: bearOptionDescription,
-					descriptionLocalizations: bearOptionDescriptionLocalizations,
+					description: bearOptionDescription["en-US"],
+					descriptionLocalizations: bearOptionDescription,
 					required: true,
 					minValue: 0,
 					maxValue: bears.length - 1,
@@ -252,7 +209,7 @@ const bearCommand: Command = {
 					return commandName;
 				},
 				bearOptionDescription: (): string => {
-					return bearOptionDescriptionLocalizations[locale];
+					return bearOptionDescription[locale];
 				},
 			};
 		}));

--- a/src/commands/chat.ts
+++ b/src/commands/chat.ts
@@ -9,157 +9,70 @@ import type {
 	ThreadChannel,
 } from "discord.js";
 import type Command from "../commands.js";
+import type {Chat as ChatCompilation} from "../compilations.js";
+import type {Chat as ChatDefinition} from "../definitions.js";
+import type {Chat as ChatDependency} from "../dependencies.js";
 import type {Locale, Localized} from "../utils/string.js";
 import {Util} from "discord.js";
-import {compileAll, composeAll, localize, resolve} from "../utils/string.js";
-type HelpGroups = {
-	commandName: () => string,
-	postSubCommandName: () => string,
-	patchSubCommandName: () => string,
-	attachSubCommandName: () => string,
-	detachSubCommandName: () => string,
-	channelOptionDescription: () => string,
-	messageOptionDescription: () => string,
-	contentOptionDescription: () => string,
-	positionOptionDescription: () => string,
-	attachmentOptionDescription: () => string,
-};
-type ReplyGroups = {};
-type BareReplyGroups = {};
-type NoPrivacyReplyGroups = {};
-type NoChannelReplyGroups = {};
-type NoMessageReplyGroups = {};
-type NoPositionReplyGroups = {
-	max: () => string,
-};
-type NoContentOrAttachmentReplyGroups = {};
-type NoInteractionReplyGroups = {};
-type NoPatchPermissionReplyGroups = {};
-type NoPostPermissionReplyGroups = {};
-const commandName: string = "chat";
-const commandDescriptionLocalizations: Localized<string> = {
-	"en-US": "Sends this content with these attachments or edits this message with them in this channel",
-	"fr": "Envoie ce contenu avec ces pièces jointes ou modifie ce message avec ceux-là dans ce salon",
-};
-const commandDescription: string = commandDescriptionLocalizations["en-US"];
-const postSubCommandName: string = "post";
-const postSubCommandDescriptionLocalizations: Localized<string> = {
-	"en-US": "Sends this content in this channel",
-	"fr": "Envoie ce contenu dans ce salon",
-};
-const postSubCommandDescription: string = postSubCommandDescriptionLocalizations["en-US"];
-const patchSubCommandName: string = "patch";
-const patchSubCommandDescriptionLocalizations: Localized<string> = {
-	"en-US": "Edits this message with this content in this channel",
-	"fr": "Modifie de message avec ce contenu dans ce salon",
-};
-const patchSubCommandDescription: string = patchSubCommandDescriptionLocalizations["en-US"];
-const attachSubCommandName: string = "attach";
-const attachSubCommandDescriptionLocalizations: Localized<string> = {
-	"en-US": "Adds at this position this attachment to this message in this channel",
-	"fr": "Ajoute à cette position cette pièce jointe à ce message dans ce salon",
-};
-const attachSubCommandDescription: string = attachSubCommandDescriptionLocalizations["en-US"];
-const detachSubCommandName: string = "detach";
-const detachSubCommandDescriptionLocalizations: Localized<string> = {
-	"en-US": "Removes at this position the attachment from this message in this channel",
-	"fr": "Retire à cette position la pièce jointe de ce message dans ce salon",
-};
-const detachSubCommandDescription: string = detachSubCommandDescriptionLocalizations["en-US"];
-const channelOptionName: string = "channel";
-const channelOptionDescriptionLocalizations: Localized<string> = {
-	"en-US": "Some channel",
-	"fr": "Un salon",
-};
-const channelOptionDescription: string = channelOptionDescriptionLocalizations["en-US"];
-const messageOptionName: string = "message";
-const messageOptionDescriptionLocalizations: Localized<string> = {
-	"en-US": "Some message",
-	"fr": "Un message",
-};
-const messageOptionDescription: string = messageOptionDescriptionLocalizations["en-US"];
-const contentOptionName: string = "content";
-const contentOptionDescriptionLocalizations: Localized<string> = {
-	"en-US": "Some content",
-	"fr": "Un contenu",
-};
-// const contentOptionDescription: string = contentOptionDescriptionLocalizations["en-US"];
-const positionOptionName: string = "position";
-const positionOptionDescriptionLocalizations: Localized<string> = {
-	"en-US": "Some position",
-	"fr": "Une position",
-};
-const positionOptionDescription: string = messageOptionDescriptionLocalizations["en-US"];
-const attachmentOptionName: string = "attachment";
-const attachmentOptionDescriptionLocalizations: Localized<string> = {
-	"en-US": "Some attachment",
-	"fr": "Une pièce jointe",
-};
-const attachmentOptionDescription: string = messageOptionDescriptionLocalizations["en-US"];
+import {chat as chatCompilation} from "../compilations.js";
+import {chat as chatDefinition} from "../definitions.js";
+import {composeAll, localize, resolve} from "../utils/string.js";
+type HelpGroups = ChatDependency["help"];
+const {
+	commandName,
+	commandDescription,
+	postSubCommandName,
+	postSubCommandDescription,
+	patchSubCommandName,
+	patchSubCommandDescription,
+	attachSubCommandName,
+	attachSubCommandDescription,
+	detachSubCommandName,
+	detachSubCommandDescription,
+	channelOptionName,
+	channelOptionDescription,
+	messageOptionName,
+	messageOptionDescription,
+	contentOptionName,
+	contentOptionDescription,
+	positionOptionName,
+	positionOptionDescription,
+	attachmentOptionName,
+	attachmentOptionDescription,
+}: ChatDefinition = chatDefinition;
+const {
+	help: helpLocalizations,
+	reply: replyLocalizations,
+	bareReply: bareReplyLocalizations,
+	noPrivacyReply: noPrivacyReplyLocalizations,
+	noChannelReply: noChannelReplyLocalizations,
+	noMessageReply: noMessageReplyLocalizations,
+	noPositionReply: noPositionReplyLocalizations,
+	noInteractionReply: noInteractionReplyLocalizations,
+	noContentOrAttachmentReply: noContentOrAttachmentReplyLocalizations,
+	noPatchPermissionReply: noPatchPermissionReplyLocalizations,
+	noPostPermissionReply: noPostPermissionReplyLocalizations,
+}: ChatCompilation = chatCompilation;
 const messagePattern: RegExp = /^(?:0|[1-9]\d*)$/;
 const channels: Set<string> = new Set<string>(["🔧│console", "🔎│logs", "🔰│helpers-room", "🛡│moderators-room"]);
-const helpLocalizations: Localized<(groups: HelpGroups) => string> = compileAll<HelpGroups>({
-	"en-US": "Type `/$<commandName> $<postSubCommandName> $<channelOptionDescription> $<contentOptionDescription>` to send `$<contentOptionDescription>` in `$<channelOptionDescription>`\nType `/$<commandName> $<patchSubCommandName> $<channelOptionDescription> $<messageOptionDescription> $<contentOptionDescription>` to edit `$<messageOptionDescription>` with `$<contentOptionDescription>` in `$<channelOptionDescription>`\nType `/$<commandName> $<attachSubCommandName> $<channelOptionDescription> $<messageOptionDescription> $<positionOptionDescription> $<attachmentOptionDescription>` to add at `$<positionOptionDescription>` `$<attachmentOptionDescription>` to `$<messageOptionDescription>` in `$<channelOptionDescription>`\nType `/$<commandName> $<detachSubCommandName> $<channelOptionDescription> $<messageOptionDescription> $<positionOptionDescription>` to remove at `$<positionOptionDescription>` the attachment of `$<messageOptionDescription>` in `$<channelOptionDescription>`",
-	"fr": "Tape `/$<commandName> $<postSubCommandName> $<channelOptionDescription> $<contentOptionDescription>` pour envoyer `$<contentOptionDescription>` dans `$<channelOptionDescription>`\nTape `/$<commandName> $<patchSubCommandName> $<channelOptionDescription> $<messageOptionDescription>` $<contentOptionDescription> pour modifier `$<messageOptionDescription>` avec `$<contentOptionDescription>` dans `$<channelOptionDescription>`\nTape `/$<commandName> $<attachSubCommandName> $<channelOptionDescription> $<messageOptionDescription> $<positionOptionDescription> $<attachmentOptionDescription>` pour ajouter à `$<positionOptionDescription>` `$<attachmentOptionDescription>` à `$<messageOptionDescription>` dans `$<channelOptionDescription>`\nTape `/$<commandName> $<detachSubCommandName> $<channelOptionDescription> $<messageOptionDescription> $<positionOptionDescription>` pour retirer à `$<positionOptionDescription>` la pièce jointe de `$<messageOptionDescription>` dans `$<channelOptionDescription>`",
-});
-const replyLocalizations: Localized<(groups: ReplyGroups) => string> = compileAll<ReplyGroups>({
-	"en-US": "I have edited the message.",
-	"fr": "J'ai modifié le message.",
-});
-const bareReplyLocalizations: Localized<(groups: BareReplyGroups) => string> = compileAll<BareReplyGroups>({
-	"en-US": "I have sent the message.",
-	"fr": "J'ai envoyé le message.",
-});
-const noPrivacyReplyLocalizations: Localized<(groups: NoPrivacyReplyGroups) => string> = compileAll<NoPrivacyReplyGroups>({
-	"en-US": "I can not reply to you in this channel.\nPlease ask me in a private channel instead.",
-	"fr": "Je ne peux pas te répondre dans ce salon.\nMerci de me demander dans un salon privé à la place.",
-});
-const noChannelReplyLocalizations: Localized<(groups: NoChannelReplyGroups) => string> = compileAll<NoChannelReplyGroups>({
-	"en-US": "I do not know any channel with this tag.",
-	"fr": "Je ne connais aucun salon avec cette étiquette.",
-});
-const noMessageReplyLocalizations: Localized<(groups: NoMessageReplyGroups) => string> = compileAll<NoMessageReplyGroups>({
-	"en-US": "I do not know any message with this identifier in this channel.",
-	"fr": "Je ne connais aucun message avec cet identifiant dans ce salon.",
-});
-const noPositionReplyLocalizations: Localized<(groups: NoPositionReplyGroups) => string> = compileAll<NoPositionReplyGroups>({
-	"en-US": "I do not know any slot with this position.\nPlease give me a position between `0` and `$<max>` instead.",
-	"fr": "Je ne connais aucun emplacement avec cette position.\nMerci de me donner une position entre `0` et `$<max>` à la place.",
-});
-const noInteractionReplyLocalizations: Localized<(groups: NoInteractionReplyGroups) => string> = compileAll<NoInteractionReplyGroups>({
-	"en-US": "I can not edit interaction replies or follow-ups.",
-	"fr": "Je ne peux pas modifier de réponses ou de suites aux interactions.",
-});
-const noContentOrAttachmentReplyLocalizations: Localized<(groups: NoContentOrAttachmentReplyGroups) => string> = compileAll<NoContentOrAttachmentReplyGroups>({
-	"en-US": "Please keep a content or attachments.",
-	"fr": "Merci de garder un contenu ou des pièces jointes.",
-});
-const noPatchPermissionReplyLocalizations: Localized<(groups: NoPatchPermissionReplyGroups) => string> = compileAll<NoPatchPermissionReplyGroups>({
-	"en-US": "I do not have the rights to edit this message.",
-	"fr": "Je n'ai pas les droits pour modifier ce message.",
-});
-const noPostPermissionReplyLocalizations: Localized<(groups: NoPostPermissionReplyGroups) => string> = compileAll<NoPostPermissionReplyGroups>({
-	"en-US": "I do not have the rights to send this message.",
-	"fr": "Je n'ai pas les droits pour envoyer ce message.",
-});
 const chatCommand: Command = {
 	register(): ApplicationCommandData {
 		return {
 			name: commandName,
-			description: commandDescription,
-			descriptionLocalizations: commandDescriptionLocalizations,
+			description: commandDescription["en-US"],
+			descriptionLocalizations: commandDescription,
 			options: [
 				{
 					type: "SUB_COMMAND",
 					name: postSubCommandName,
-					description: postSubCommandDescription,
-					descriptionLocalizations: postSubCommandDescriptionLocalizations,
+					description: postSubCommandDescription["en-US"],
+					descriptionLocalizations: postSubCommandDescription,
 					options: [
 						{
 							type: "CHANNEL",
 							name: channelOptionName,
-							description: channelOptionDescription,
-							descriptionLocalizations: channelOptionDescriptionLocalizations,
+							description: channelOptionDescription["en-US"],
+							descriptionLocalizations: channelOptionDescription,
 							required: true,
 							channelTypes: [
 								"GUILD_TEXT",
@@ -175,14 +88,14 @@ const chatCommand: Command = {
 				{
 					type: "SUB_COMMAND",
 					name: patchSubCommandName,
-					description: patchSubCommandDescription,
-					descriptionLocalizations: patchSubCommandDescriptionLocalizations,
+					description: patchSubCommandDescription["en-US"],
+					descriptionLocalizations: patchSubCommandDescription,
 					options: [
 						{
 							type: "CHANNEL",
 							name: channelOptionName,
-							description: channelOptionDescription,
-							descriptionLocalizations: channelOptionDescriptionLocalizations,
+							description: channelOptionDescription["en-US"],
+							descriptionLocalizations: channelOptionDescription,
 							required: true,
 							channelTypes: [
 								"GUILD_TEXT",
@@ -196,8 +109,8 @@ const chatCommand: Command = {
 						{
 							type: "STRING",
 							name: messageOptionName,
-							description: messageOptionDescription,
-							descriptionLocalizations: messageOptionDescriptionLocalizations,
+							description: messageOptionDescription["en-US"],
+							descriptionLocalizations: messageOptionDescription,
 							required: true,
 						},
 					],
@@ -205,14 +118,14 @@ const chatCommand: Command = {
 				{
 					type: "SUB_COMMAND",
 					name: attachSubCommandName,
-					description: attachSubCommandDescription,
-					descriptionLocalizations: attachSubCommandDescriptionLocalizations,
+					description: attachSubCommandDescription["en-US"],
+					descriptionLocalizations: attachSubCommandDescription,
 					options: [
 						{
 							type: "CHANNEL",
 							name: channelOptionName,
-							description: channelOptionDescription,
-							descriptionLocalizations: channelOptionDescriptionLocalizations,
+							description: channelOptionDescription["en-US"],
+							descriptionLocalizations: channelOptionDescription,
 							required: true,
 							channelTypes: [
 								"GUILD_TEXT",
@@ -226,23 +139,23 @@ const chatCommand: Command = {
 						{
 							type: "STRING",
 							name: messageOptionName,
-							description: messageOptionDescription,
-							descriptionLocalizations: messageOptionDescriptionLocalizations,
+							description: messageOptionDescription["en-US"],
+							descriptionLocalizations: messageOptionDescription,
 							required: true,
 						},
 						{
 							type: "INTEGER",
 							name: positionOptionName,
-							description: positionOptionDescription,
-							descriptionLocalizations: positionOptionDescriptionLocalizations,
+							description: positionOptionDescription["en-US"],
+							descriptionLocalizations: positionOptionDescription,
 							required: true,
 							minValue: 0,
 						},
 						{
 							type: "ATTACHMENT",
 							name: attachmentOptionName,
-							description: attachmentOptionDescription,
-							descriptionLocalizations: attachmentOptionDescriptionLocalizations,
+							description: attachmentOptionDescription["en-US"],
+							descriptionLocalizations: attachmentOptionDescription,
 							required: true,
 						},
 					],
@@ -250,14 +163,14 @@ const chatCommand: Command = {
 				{
 					type: "SUB_COMMAND",
 					name: detachSubCommandName,
-					description: detachSubCommandDescription,
-					descriptionLocalizations: detachSubCommandDescriptionLocalizations,
+					description: detachSubCommandDescription["en-US"],
+					descriptionLocalizations: detachSubCommandDescription,
 					options: [
 						{
 							type: "CHANNEL",
 							name: channelOptionName,
-							description: channelOptionDescription,
-							descriptionLocalizations: channelOptionDescriptionLocalizations,
+							description: channelOptionDescription["en-US"],
+							descriptionLocalizations: channelOptionDescription,
 							required: true,
 							channelTypes: [
 								"GUILD_TEXT",
@@ -271,15 +184,15 @@ const chatCommand: Command = {
 						{
 							type: "STRING",
 							name: messageOptionName,
-							description: messageOptionDescription,
-							descriptionLocalizations: messageOptionDescriptionLocalizations,
+							description: messageOptionDescription["en-US"],
+							descriptionLocalizations: messageOptionDescription,
 							required: true,
 						},
 						{
 							type: "INTEGER",
 							name: positionOptionName,
-							description: positionOptionDescription,
-							descriptionLocalizations: positionOptionDescriptionLocalizations,
+							description: positionOptionDescription["en-US"],
+							descriptionLocalizations: positionOptionDescription,
 							required: true,
 							minValue: 0,
 						},
@@ -359,7 +272,7 @@ const chatCommand: Command = {
 			}
 			await interaction.showModal({
 				customId: interaction.id,
-				title: contentOptionDescriptionLocalizations[resolvedLocale],
+				title: contentOptionDescription[resolvedLocale],
 				components: [
 					{
 						type: "ACTION_ROW",
@@ -415,7 +328,7 @@ const chatCommand: Command = {
 		if (subCommandName === postSubCommandName) {
 			await interaction.showModal({
 				customId: interaction.id,
-				title: contentOptionDescriptionLocalizations[resolvedLocale],
+				title: contentOptionDescription[resolvedLocale],
 				components: [
 					{
 						type: "ACTION_ROW",
@@ -615,19 +528,19 @@ const chatCommand: Command = {
 					return detachSubCommandName;
 				},
 				channelOptionDescription: (): string => {
-					return channelOptionDescriptionLocalizations[locale];
+					return channelOptionDescription[locale];
 				},
 				messageOptionDescription: (): string => {
-					return messageOptionDescriptionLocalizations[locale];
+					return messageOptionDescription[locale];
 				},
 				contentOptionDescription: (): string => {
-					return contentOptionDescriptionLocalizations[locale];
+					return contentOptionDescription[locale];
 				},
 				positionOptionDescription: (): string => {
-					return positionOptionDescriptionLocalizations[locale];
+					return positionOptionDescription[locale];
 				},
 				attachmentOptionDescription: (): string => {
-					return attachmentOptionDescriptionLocalizations[locale];
+					return attachmentOptionDescription[locale];
 				},
 			};
 		}));

--- a/src/commands/count.ts
+++ b/src/commands/count.ts
@@ -5,36 +5,29 @@ import type {
 	Interaction,
 } from "discord.js";
 import type Command from "../commands.js";
+import type {Count as CountCompilation} from "../compilations.js";
+import type {Count as CountDefinition} from "../definitions.js";
+import type {Count as CountDependency} from "../dependencies.js";
 import type {Locale, Localized} from "../utils/string.js";
 import {Util} from "discord.js";
-import {compileAll, composeAll, localize, resolve} from "../utils/string.js";
-type HelpGroups = {
-	commandName: () => string,
-};
-type ReplyGroups = {
-	memberCount: () => string,
-	name: () => string,
-};
-const commandName: string = "count";
-const commandDescriptionLocalizations: Localized<string> = {
-	"en-US": "Tells you what is the number of members on the server",
-	"fr": "Te dit quel est le nombre de membres sur le serveur",
-};
-const commandDescription: string = commandDescriptionLocalizations["en-US"];
-const helpLocalizations: Localized<(groups: HelpGroups) => string> = compileAll<HelpGroups>({
-	"en-US": "Type `/$<commandName>` to know what is the number of members on the server",
-	"fr": "Tape `/$<commandName>` pour savoir quel est le nombre de membres sur le serveur",
-});
-const replyLocalizations: Localized<(groups: ReplyGroups) => string> = compileAll<ReplyGroups>({
-	"en-US": "There are $<memberCount> members on the official *$<name>* *Discord* server!",
-	"fr": "Il y a $<memberCount> membres sur le serveur *Discord* officiel de *$<name>* !",
-});
+import {count as countCompilation} from "../compilations.js";
+import {count as countDefinition} from "../definitions.js";
+import {composeAll, localize, resolve} from "../utils/string.js";
+type HelpGroups = CountDependency["help"];
+const {
+	commandName,
+	commandDescription,
+}: CountDefinition = countDefinition;
+const {
+	help: helpLocalizations,
+	reply: replyLocalizations,
+}: CountCompilation = countCompilation;
 const countCommand: Command = {
 	register(): ApplicationCommandData {
 		return {
 			name: commandName,
-			description: commandDescription,
-			descriptionLocalizations: commandDescriptionLocalizations,
+			description: commandDescription["en-US"],
+			descriptionLocalizations: commandDescription,
 		};
 	},
 	async execute(interaction: Interaction): Promise<void> {

--- a/src/commands/emoji.ts
+++ b/src/commands/emoji.ts
@@ -12,40 +12,34 @@ import type {
 	CanvasRenderingContext2D,
 } from "canvas";
 import type Command from "../commands.js";
+import type {Emoji as EmojiCompilation} from "../compilations.js";
+import type {Emoji as EmojiDefinition} from "../definitions.js";
+import type {Emoji as EmojiDependency} from "../dependencies.js";
 import type {Locale, Localized} from "../utils/string.js";
 import {readFile} from "node:fs/promises";
 import {fileURLToPath} from "node:url";
 import canvas from "canvas";
 import {JSDOM} from "jsdom";
 import serialize from "w3c-xmlserializer";
-import {compileAll, composeAll, localize, resolve} from "../utils/string.js";
-type HelpGroups = {
-	commandName: () => string,
-	baseOptionDescription: () => string,
-	stylesOptionDescription: () => string,
-};
-type NoPrivacyReplyGroups = {};
+import {emoji as emojiCompilation} from "../compilations.js";
+import {emoji as emojiDefinition} from "../definitions.js";
+import {composeAll, localize, resolve} from "../utils/string.js";
+type HelpGroups = EmojiDependency["help"];
+const {
+	commandName,
+	commandDescription,
+	baseOptionName,
+	baseOptionDescription,
+	// stylesOptionName,
+	stylesOptionDescription,
+}: EmojiDefinition = emojiDefinition;
+const {
+	help: helpLocalizations,
+	noPrivacyReply: noPrivacyReplyLocalizations,
+}: EmojiCompilation = emojiCompilation;
 const {createCanvas, loadImage}: any = canvas;
 const here: string = import.meta.url;
 const root: string = here.slice(0, here.lastIndexOf("/"));
-const commandName: string = "emoji";
-const commandDescriptionLocalizations: Localized<string> = {
-	"en-US": "Creates a new emoji starting from this base and customized with these styles",
-	"fr": "Crée un nouvel émoji à partir de cette base et personnalisé avec ces styles",
-};
-const commandDescription: string = "Creates a new emoji starting from this base and customized with these styles";
-const baseOptionName: string = "base";
-const baseOptionDescriptionLocalizations: Localized<string> = {
-	"en-US": "Some base",
-	"fr": "Une base",
-};
-const baseOptionDescription: string = baseOptionDescriptionLocalizations["en-US"];
-// const stylesOptionName: string = "styles";
-const stylesOptionDescriptionLocalizations: Localized<string> = {
-	"en-US": "Some styles",
-	"fr": "Des styles",
-};
-const stylesOptionDescription: string = stylesOptionDescriptionLocalizations["en-US"];
 const bases: Set<string> = new Set(["baaren", "shicka", "baaren-outlined", "shicka-outlined", "baaren-discord", "shicka-discord"]);
 const paints: Set<"fill" | "stroke"> = new Set(["fill", "stroke"]);
 const layers: Set<"background" | "foreground" | "marker"> = new Set(["background", "foreground", "marker"]);
@@ -63,26 +57,18 @@ const styles: {[k in string]: string} = Object.assign(Object.create(null), {
 	"none": "none",
 });
 const channels: Set<string> = new Set<string>(["🔧│console", "🔎│logs", "🔰│helpers-room", "🛡│moderators-room", "🍪│cookie-room"]);
-const helpLocalizations: Localized<(groups: HelpGroups) => string> = compileAll<HelpGroups>({
-	"en-US": "Type `/$<commandName> $<baseOptionDescription> $<stylesOptionDescription>` to create a new `$<baseOptionDescription>`-based emoji customized with `$<stylesOptionDescription>`",
-	"fr": "Tape `/$<commandName> $<baseOptionDescription> $<stylesOptionDescription>` pour créer un nouvel émoji basé sur `$<baseOptionDescription>` personnalisé avec `$<stylesOptionDescription>`",
-});
-const noPrivacyReplyLocalizations: Localized<(groups: NoPrivacyReplyGroups) => string> = compileAll<NoPrivacyReplyGroups>({
-	"en-US": "I can not reply to you in this channel.\nPlease ask me in a private channel instead.",
-	"fr": "Je ne peux pas te répondre dans ce salon.\nMerci de me demander dans un salon privé à la place.",
-});
 const emojiCommand: Command = {
 	register(): ApplicationCommandData {
 		return {
 			name: commandName,
-			description: commandDescription,
-			descriptionLocalizations: commandDescriptionLocalizations,
+			description: commandDescription["en-US"],
+			descriptionLocalizations: commandDescription,
 			options: [
 				{
 					type: "STRING",
 					name: baseOptionName,
-					description: baseOptionDescription,
-					descriptionLocalizations: baseOptionDescriptionLocalizations,
+					description: baseOptionDescription["en-US"],
+					descriptionLocalizations: baseOptionDescription,
 					required: true,
 					choices: Array.from(bases, (base: string): ApplicationCommandOptionChoiceData => {
 						return {
@@ -94,13 +80,12 @@ const emojiCommand: Command = {
 				...Array.from(paints, (paint: string): ApplicationCommandOptionData[] => {
 					return Array.from(layers, (layer: string): ApplicationCommandOptionData => {
 						const optionName: string = `${layer}-${paint}`;
-						const optionDescription: string = stylesOptionDescription;
-						const optionDescriptionLocalizations: Localized<string> = stylesOptionDescriptionLocalizations;
+						const optionDescription: Localized<string> = stylesOptionDescription;
 						return {
 							type: "STRING",
 							name: optionName,
-							description: optionDescription,
-							descriptionLocalizations: optionDescriptionLocalizations,
+							description: optionDescription["en-US"],
+							descriptionLocalizations: optionDescription,
 							choices: Object.keys(styles).map((style: string): ApplicationCommandOptionChoiceData => {
 								return {
 									name: style,
@@ -201,10 +186,10 @@ const emojiCommand: Command = {
 					return commandName;
 				},
 				baseOptionDescription: (): string => {
-					return baseOptionDescriptionLocalizations[locale];
+					return baseOptionDescription[locale];
 				},
 				stylesOptionDescription: (): string => {
-					return stylesOptionDescriptionLocalizations[locale];
+					return stylesOptionDescription[locale];
 				},
 			};
 		}));

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -124,6 +124,7 @@ const helpCommand: Command = {
 					},
 				});
 				replied = true;
+				continue;
 			}
 			await interaction.followUp({
 				content: chunk,
@@ -154,6 +155,7 @@ const helpCommand: Command = {
 					},
 				});
 				replied = true;
+				continue;
 			}
 			await interaction.followUp({
 				content: chunk,

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -2,37 +2,29 @@ import type {
 	ApplicationCommandData,
 	CommandInteraction,
 	Interaction,
-	User,
 } from "discord.js";
 import type Command from "../commands.js";
+import type {Help as HelpCompilation} from "../compilations.js";
+import type {Help as HelpDefinition} from "../definitions.js";
+import type {Help as HelpDependency} from "../dependencies.js";
 import type Feed from "../feeds.js";
 import type Trigger from "../triggers.js";
 import type {Locale, Localized} from "../utils/string.js";
 import * as commands from "../commands.js";
+import {help as helpCompilation} from "../compilations.js";
+import {help as helpDefinition} from "../definitions.js";
 import * as feeds from "../feeds.js";
 import * as triggers from "../triggers.js";
-import {compileAll, composeAll, list, localize, resolve} from "../utils/string.js";
-type HelpGroups = {
-	commandName: () => string,
-};
-type ReplyGroups = {
-	user: () => string,
-	featureList: () => string,
-};
-const commandName: string = "help";
-const commandDescriptionLocalizations: Localized<string> = {
-	"en-US": "Tells you what are the features I offer",
-	"fr": "Te dit quelles sont les fonctionnalités que je propose",
-};
-const commandDescription: string = commandDescriptionLocalizations["en-US"];
-const helpLocalizations: Localized<(groups: HelpGroups) => string> = compileAll<HelpGroups>({
-	"en-US": "Type `/$<commandName>` to know what are the features I offer",
-	"fr": "Tape `/$<commandName>` pour savoir quelles sont les fonctionnalités que je propose",
-});
-const replyLocalizations: Localized<(groups: ReplyGroups) => string> = compileAll<ReplyGroups>({
-	"en-US": "Hey $<user>, there you are!\nI can give you some advice about the server:\n$<featureList>",
-	"fr": "Ah $<user>, tu es là !\nJe peux te donner des conseils sur le serveur :\n$<featureList>",
-});
+import {composeAll, list, localize, resolve} from "../utils/string.js";
+type HelpGroups = HelpDependency["help"];
+const {
+	commandName,
+	commandDescription,
+}: HelpDefinition = helpDefinition;
+const {
+	help: helpLocalizations,
+	reply: replyLocalizations,
+}: HelpCompilation = helpCompilation;
 function naiveStream(content: string): string[] {
 	content = content.replace(/^\n+|\n+$/g, "").replace(/\n+/g, "\n");
 	if (content.length === 0) {
@@ -69,8 +61,8 @@ const helpCommand: Command = {
 	register(): ApplicationCommandData {
 		return {
 			name: commandName,
-			description: commandDescription,
-			descriptionLocalizations: commandDescriptionLocalizations,
+			description: commandDescription["en-US"],
+			descriptionLocalizations: commandDescription,
 		};
 	},
 	async execute(interaction: Interaction): Promise<void> {

--- a/src/commands/leaderboard.ts
+++ b/src/commands/leaderboard.ts
@@ -4,29 +4,29 @@ import type {
 	Interaction,
 } from "discord.js";
 import type Command from "../commands.js";
+import type {Leaderboard as LeaderboardCompilation} from "../compilations.js";
+import type {Leaderboard as LeaderboardDefinition} from "../definitions.js";
+import type {Leaderboard as LeaderboardDependency} from "../dependencies.js";
 import type {Locale, Localized} from "../utils/string.js";
 import {Util} from "discord.js";
-import {compileAll, composeAll, list, localize, resolve} from "../utils/string.js";
-type HelpGroups = {
-	commandName: () => string,
-};
-type ReplyGroups = {
-	linkList: () => string,
-};
-type LinkGroups = {
-	title: () => string,
-	link: () => string,
-};
+import {leaderboard as leaderboardCompilation} from "../compilations.js";
+import {leaderboard as leaderboardDefinition} from "../definitions.js";
+import {composeAll, list, localize, resolve} from "../utils/string.js";
+type HelpGroups = LeaderboardDependency["help"];
+type LinkGroups = LeaderboardDependency["link"];
 type Data = {
 	title: string,
 	link: string,
 };
-const commandName: string = "leaderboard";
-const commandDescriptionLocalizations: Localized<string> = {
-	"en-US": "Tells you where to watch community speedruns of the game",
-	"fr": "Te dit où regarder des speedruns communautaires du jeu",
-};
-const commandDescription: string = commandDescriptionLocalizations["en-US"];
+const {
+	commandName,
+	commandDescription,
+}: LeaderboardDefinition = leaderboardDefinition;
+const {
+	help: helpLocalizations,
+	reply: replyLocalizations,
+	link: linkLocalizations,
+}: LeaderboardCompilation = leaderboardCompilation;
 const data: Data[] = [
 	{
 		title: "Full-game",
@@ -61,24 +61,12 @@ const data: Data[] = [
 		link: "https://www.speedrun.com/sbace",
 	},
 ];
-const helpLocalizations: Localized<(groups: HelpGroups) => string> = compileAll<HelpGroups>({
-	"en-US": "Type `/$<commandName>` to know where to watch community speedruns of the game",
-	"fr": "Tape `/$<commandName>` pour savoir où regarder des speedruns communautaires du jeu",
-});
-const replyLocalizations: Localized<(groups: ReplyGroups) => string> = compileAll<ReplyGroups>({
-	"en-US": "You can watch community speedruns there:\n$<linkList>",
-	"fr": "Tu peux regarder des speedruns communautaires là :\n$<linkList>",
-});
-const linkLocalizations: Localized<((groups: LinkGroups) => string)> = compileAll<LinkGroups>({
-	"en-US": "[*$<title>* leaderboard](<$<link>>)",
-	"fr": "[Classement *$<title>*](<$<link>>)",
-});
 const leaderboardCommand: Command = {
 	register(): ApplicationCommandData {
 		return {
 			name: commandName,
-			description: commandDescription,
-			descriptionLocalizations: commandDescriptionLocalizations,
+			description: commandDescription["en-US"],
+			descriptionLocalizations: commandDescription,
 		};
 	},
 	async execute(interaction: Interaction): Promise<void> {

--- a/src/commands/mission.ts
+++ b/src/commands/mission.ts
@@ -9,84 +9,45 @@ import type {
 } from "discord.js";
 import type {Challenge, Level, Mission} from "../bindings.js";
 import type Command from "../commands.js";
+import type {Mission as MissionCompilation} from "../compilations.js";
+import type {Mission as MissionDefinition} from "../definitions.js";
+import type {Mission as MissionDependency} from "../dependencies.js";
 import type {Locale, Localized} from "../utils/string.js";
 import {Util} from "discord.js";
 import {challenges, levels, missions} from "../bindings.js";
-import {compileAll, composeAll, list, localize, nearest, resolve} from "../utils/string.js";
-type HelpGroups = {
-	commandName: () => string,
-	missionOptionDescription: () => string,
-};
-type ReplyGroups = {
-	challengeName: () => string,
-	levelName: () => string,
-	scheduleList: () => string,
-};
-type BareReplyGroups = {
-	dayTime: () => string,
-	scheduleList: () => string,
-};
-type MissionNameGroups = {
-	challengeName: () => string,
-	levelName: () => string,
-};
-type ScheduleGroups = {
-	dayDateTime: () => string,
-};
-type BareScheduleGroups = {
-	dayDate: () => string,
-	challengeName: () => string,
-	levelName: () => string,
-};
-const commandName: string = "mission";
-const commandDescriptionLocalizations: Localized<string> = {
-	"en-US": "Tells you what is playable in the shop or when it is playable",
-	"fr": "Te dit ce qui est jouable dans la boutique ou quand c'est jouable",
-};
-const commandDescription: string = commandDescriptionLocalizations["en-US"];
-const missionOptionName: string = "mission";
-const missionOptionDescriptionLocalizations: Localized<string> = {
-	"en-US": "Some mission",
-	"fr": "Une mission",
-};
-const missionOptionDescription: string = missionOptionDescriptionLocalizations["en-US"];
+import {mission as missionCompilation} from "../compilations.js";
+import {mission as missionDefinition} from "../definitions.js";
+import {composeAll, list, localize, nearest, resolve} from "../utils/string.js";
+type HelpGroups = MissionDependency["help"];
+type ScheduleGroups = MissionDependency["schedule"];
+type BareScheduleGroups = MissionDependency["bareSchedule"];
+const {
+	commandName,
+	commandDescription,
+	missionOptionName,
+	missionOptionDescription,
+}: MissionDefinition = missionDefinition;
+const {
+	help: helpLocalizations,
+	reply: replyLocalizations,
+	bareReply: bareReplyLocalizations,
+	missionName: missionNameLocalizations,
+	schedule: scheduleLocalizations,
+	bareSchedule: bareScheduleLocalizations,
+}: MissionCompilation = missionCompilation;
 const dayTime: Date = new Date(36000000);
-const helpLocalizations: Localized<(groups: HelpGroups) => string> = compileAll<HelpGroups>({
-	"en-US": "Type `/$<commandName>` to know what is playable in the shop\nType `/$<commandName> $<missionOptionDescription>` to know when `$<missionOptionDescription>` is playable in the shop",
-	"fr": "Tape `/$<commandName>` pour savoir ce qui est jouable dans la boutique\nTape `/$<commandName> $<missionOptionDescription>` pour savoir quand `$<missionOptionDescription>` est jouable dans la boutique",
-});
-const replyLocalizations: Localized<(groups: ReplyGroups) => string> = compileAll<ReplyGroups>({
-	"en-US": "**$<challengeName>** in **$<levelName>** will be playable for 1 day starting:\n$<scheduleList>",
-	"fr": "**$<challengeName>** dans **$<levelName>** sera jouable durant 1 jour à partir de :\n$<scheduleList>",
-});
-const bareReplyLocalizations: Localized<(groups: BareReplyGroups) => string> = compileAll<BareReplyGroups>({
-	"en-US": "Each mission starts at *$<dayTime>*:\n$<scheduleList>",
-	"fr": "Chaque mission commence à *$<dayTime>* :\n$<scheduleList>",
-});
-const missionNameLocalizations: Localized<((groups: MissionNameGroups) => string)> = compileAll<MissionNameGroups>({
-	"en-US": "$<challengeName> in $<levelName>",
-	"fr": "$<challengeName> dans $<levelName>",
-});
-const scheduleLocalizations: Localized<((groups: ScheduleGroups) => string)> = compileAll<ScheduleGroups>({
-	"en-US": "*$<dayDateTime>*",
-	"fr": "*$<dayDateTime>*",
-});
-const bareScheduleLocalizations: Localized<((groups: BareScheduleGroups) => string)> = compileAll<BareScheduleGroups>({
-	"en-US": "*$<dayDate>*: **$<challengeName>** in **$<levelName>**",
-	"fr": "*$<dayDate>* : **$<challengeName>** dans **$<levelName>**",
-});
 const missionCommand: Command = {
 	register(): ApplicationCommandData {
 		return {
 			name: commandName,
-			description: commandDescription,
-			descriptionLocalizations: commandDescriptionLocalizations,
+			description: commandDescription["en-US"],
+			descriptionLocalizations: commandDescription,
 			options: [
 				((): ApplicationCommandOptionData & {minValue: number, maxValue: number} => ({
 					type: "INTEGER",
 					name: missionOptionName,
-					description: missionOptionDescription,
-					descriptionLocalizations: missionOptionDescriptionLocalizations,
+					description: missionOptionDescription["en-US"],
+					descriptionLocalizations: missionOptionDescription,
 					minValue: 0,
 					maxValue: missions.length - 1,
 					autocomplete: true,
@@ -276,7 +237,7 @@ const missionCommand: Command = {
 					return commandName;
 				},
 				missionOptionDescription: (): string => {
-					return missionOptionDescriptionLocalizations[locale];
+					return missionOptionDescription[locale];
 				},
 			};
 		}));

--- a/src/commands/outfit.ts
+++ b/src/commands/outfit.ts
@@ -9,91 +9,41 @@ import type {
 } from "discord.js";
 import type {Outfit, Rarity} from "../bindings.js";
 import type Command from "../commands.js";
+import type {Outfit as OutfitCompilation} from "../compilations.js";
+import type {Outfit as OutfitDefinition} from "../definitions.js";
+import type {Outfit as OutfitDependency} from "../dependencies.js";
 import type {Locale, Localized} from "../utils/string.js";
 import {Util} from "discord.js";
 import {outfits, rarities} from "../bindings.js";
+import {outfit as outfitCompilation} from "../compilations.js";
+import {outfit as outfitDefinition} from "../definitions.js";
 import {outfitsByRarity} from "../indices.js";
-import {compileAll, composeAll, list, localize, nearest, resolve} from "../utils/string.js";
-type HelpGroups = {
-	commandName: () => string,
-	outfitOptionDescription: () => string,
-};
-type ReplyGroups = {
-	outfitName: () => string,
-	costConjunction: () => string,
-	scheduleList: () => string,
-};
-type BareReplyGroups = {
-	scheduleList: () => string,
-};
-type NoSlotReplyGroups = {
-	outfitName: () => string,
-};
-type TokensCostGroups = {
-	tokens: () => string,
-};
-type CoinsCostGroups = {
-	coins: () => string,
-};
-type NoCostGroups = {};
-type ScheduleGroups = {
-	dayDateTime: () => string,
-};
-type BareScheduleGroups = {
-	dayDateTime: () => string,
-	outfitNameConjunction: () => string,
-};
+import {composeAll, list, localize, nearest, resolve} from "../utils/string.js";
+type HelpGroups = OutfitDependency["help"];
+type TokensCostGroups = OutfitDependency["tokensCost"];
+type CoinsCostGroups = OutfitDependency["coinsCost"];
+type ScheduleGroups = OutfitDependency["schedule"];
+type BareScheduleGroups = OutfitDependency["bareSchedule"];
+const {
+	commandName,
+	commandDescription,
+	outfitOptionName,
+	outfitOptionDescription,
+}: OutfitDefinition = outfitDefinition;
+const {
+	help: helpLocalizations,
+	reply: replyLocalizations,
+	bareReply: bareReplyLocalizations,
+	noSlotReply: noSlotReplyLocalizations,
+	tokensCost: tokensCostLocalizations,
+	coinsCost: coinsCostLocalizations,
+	noCost: noCostLocalizations,
+	schedule: scheduleLocalizations,
+	bareSchedule: bareScheduleLocalizations,
+}: OutfitCompilation = outfitCompilation;
 const {
 	SHICKA_SALT: salt = "",
 }: NodeJS.ProcessEnv = process.env;
-const commandName: string = "outfit";
-const commandDescriptionLocalizations: Localized<string> = {
-	"en-US": "Tells you what is for sale in the shop or when it is for sale",
-	"fr": "Te dit ce qui est en vente dans la boutique ou quand c'est en vente",
-};
-const commandDescription: string = commandDescriptionLocalizations["en-US"];
-const outfitOptionName: string = "outfit";
-const outfitOptionDescriptionLocalizations: Localized<string> = {
-	"en-US": "Some outfit",
-	"fr": "Un costume",
-};
-const outfitOptionDescription: string = outfitOptionDescriptionLocalizations["en-US"];
-const helpLocalizations: Localized<(groups: HelpGroups) => string> = compileAll<HelpGroups>({
-	"en-US": "Type `/$<commandName>` to know what is for sale in the shop\nType `/$<commandName> $<outfitOptionDescription>` to know when `$<outfitOptionDescription>` is for sale in the shop",
-	"fr": "Tape `/$<commandName>` pour savoir ce qui est en vente dans la boutique\nTape `/$<commandName> $<outfitOptionDescription>` pour savoir quand `$<outfitOptionDescription>` est en vente dans la boutique",
-});
-const replyLocalizations: Localized<(groups: ReplyGroups) => string> = compileAll<ReplyGroups>({
-	"en-US": "**$<outfitName>** will be for sale in the shop for $<costConjunction> for 6 hours starting:\n$<scheduleList>",
-	"fr": "**$<outfitName>** sera en vente dans la boutique pour $<costConjunction> durant 6 heures à partir de :\n$<scheduleList>",
-});
-const noSlotReplyLocalizations: Localized<(groups: NoSlotReplyGroups) => string> = compileAll<NoSlotReplyGroups>({
-	"en-US": "**$<outfitName>** is not for sale.",
-	"fr": "**$<outfitName>** n'est pas en vente.",
-});
-const bareReplyLocalizations: Localized<(groups: BareReplyGroups) => string> = compileAll<BareReplyGroups>({
-	"en-US": "The outfits for sale in the shop change every 6 hours:\n$<scheduleList>",
-	"fr": "Les costumes en vente dans la boutique changent toutes les 6 heures :\n$<scheduleList>",
-});
-const tokensCostLocalizations: Localized<(groups: TokensCostGroups) => string> = compileAll<TokensCostGroups>({
-	"en-US": "**$<tokens> Tristopio tokens**",
-	"fr": "**$<tokens> jetons Tristopio**",
-});
-const coinsCostLocalizations: Localized<(groups: CoinsCostGroups) => string> = compileAll<CoinsCostGroups>({
-	"en-US": "**$<coins> coins**",
-	"fr": "**$<coins> pièces**",
-});
-const noCostLocalizations: Localized<(groups: NoCostGroups) => string> = compileAll<NoCostGroups>({
-	"en-US": "a pittance",
-	"fr": "une bouchée de pain",
-});
-const scheduleLocalizations: Localized<((groups: ScheduleGroups) => string)> = compileAll<ScheduleGroups>({
-	"en-US": "*$<dayDateTime>*",
-	"fr": "*$<dayDateTime>*",
-});
-const bareScheduleLocalizations: Localized<((groups: BareScheduleGroups) => string)> = compileAll<BareScheduleGroups>({
-	"en-US": "*$<dayDateTime>*: $<outfitNameConjunction>",
-	"fr": "*$<dayDateTime>* : $<outfitNameConjunction>",
-});
 function knuth(state: bigint): bigint {
 	return BigInt.asUintN(32, state * 2654435761n);
 }
@@ -156,14 +106,14 @@ const outfitCommand: Command = {
 	register(): ApplicationCommandData {
 		return {
 			name: commandName,
-			description: commandDescription,
-			descriptionLocalizations: commandDescriptionLocalizations,
+			description: commandDescription["en-US"],
+			descriptionLocalizations: commandDescription,
 			options: [
 				((): ApplicationCommandOptionData & {minValue: number, maxValue: number} => ({
 					type: "INTEGER",
 					name: outfitOptionName,
-					description: outfitOptionDescription,
-					descriptionLocalizations: outfitOptionDescriptionLocalizations,
+					description: outfitOptionDescription["en-US"],
+					descriptionLocalizations: outfitOptionDescription,
 					minValue: 0,
 					maxValue: outfits.length - 1,
 					autocomplete: true,
@@ -411,7 +361,7 @@ const outfitCommand: Command = {
 					return commandName;
 				},
 				outfitOptionDescription: (): string => {
-					return outfitOptionDescriptionLocalizations[locale];
+					return outfitOptionDescription[locale];
 				},
 			};
 		}));

--- a/src/commands/raw.ts
+++ b/src/commands/raw.ts
@@ -6,63 +6,41 @@ import type {
 } from "discord.js";
 import type Binding from "../bindings.js";
 import type Command from "../commands.js";
+import type {Raw as RawCompilation} from "../compilations.js";
+import type {Raw as RawDefinition} from "../definitions.js";
+import type {Raw as RawDependency} from "../dependencies.js";
 import type {Locale, Localized} from "../utils/string.js";
 import {Util} from "discord.js";
 import * as bindings from "../bindings.js";
-import {compileAll, composeAll, localize, resolve} from "../utils/string.js";
-type HelpGroups = {
-	commandName: () => string,
-	typeOptionDescription: () => string,
-	identifierOptionDescription: () => string,
-};
-type NoTypeReplyGroups = {
-	typeConjunction: () => string,
-};
-type NoIdentifierReplyGroups = {
-	max: () => string,
-};
-const commandName: string = "raw";
-const commandDescriptionLocalizations: Localized<string> = {
-	"en-US": "Tells you what is the datum of this type with this identifier",
-	"fr": "Te dit quelle est la donnée de ce type avec cet identifiant",
-};
-const commandDescription: string = commandDescriptionLocalizations["en-US"];
-const typeOptionName: string = "type";
-const typeOptionDescriptionLocalizations: Localized<string> = {
-	"en-US": "Some type",
-	"fr": "Un type",
-};
-const typeOptionDescription: string = typeOptionDescriptionLocalizations["en-US"];
-const identifierOptionName: string = "identifier";
-const identifierOptionDescriptionLocalizations: Localized<string> = {
-	"en-US": "Some identifier",
-	"fr": "Un identifiant",
-};
-const identifierOptionDescription: string = identifierOptionDescriptionLocalizations["en-US"];
-const helpLocalizations: Localized<(groups: HelpGroups) => string> = compileAll<HelpGroups>({
-	"en-US": "Type `/$<commandName> $<typeOptionDescription> $<identifierOptionDescription>` to know what is the datum of `$<typeOptionDescription>` with `$<identifierOptionDescription>`",
-	"fr": "Tape `/$<commandName> $<typeOptionDescription> $<identifierOptionDescription>` pour savoir quel est la donnée d'`$<typeOptionDescription>` avec `$<identifierOptionDescription>`",
-});
-const noTypeReplyLocalizations: Localized<(groups: NoTypeReplyGroups) => string> = compileAll<NoTypeReplyGroups>({
-	"en-US": "I do not know any datum with this name.\nPlease give me a type among $<typeConjunction> instead.",
-	"fr": "Je ne connais aucune donnée avec ce nom.\nMerci de me donner un type parmi $<typeConjunction> à la place.",
-});
-const noIdentifierReplyLocalizations: Localized<(groups: NoIdentifierReplyGroups) => string> = compileAll<NoIdentifierReplyGroups>({
-	"en-US": "I do not know any datum with this identifier.\nPlease give me an identifier between `0` and `$<max>` instead.",
-	"fr": "Je ne connais aucune donnée avec cet identifiant.\nMerci de me donner un identifiant entre `0` et `$<max>` à la place.",
-});
+import {raw as rawCompilation} from "../compilations.js";
+import {raw as rawDefinition} from "../definitions.js";
+import {composeAll, localize, resolve} from "../utils/string.js";
+type HelpGroups = RawDependency["help"];
+const {
+	commandName,
+	commandDescription,
+	typeOptionName,
+	typeOptionDescription,
+	identifierOptionName,
+	identifierOptionDescription,
+}: RawDefinition = rawDefinition;
+const {
+	help: helpLocalizations,
+	noTypeReply: noTypeReplyLocalizations,
+	noIdentifierReply: noIdentifierReplyLocalizations,
+}: RawCompilation = rawCompilation;
 const rawCommand: Command = {
 	register(): ApplicationCommandData {
 		return {
 			name: commandName,
-			description: commandDescription,
-			descriptionLocalizations: commandDescriptionLocalizations,
+			description: commandDescription["en-US"],
+			descriptionLocalizations: commandDescription,
 			options: [
 				{
 					type: "STRING",
 					name: typeOptionName,
-					description: typeOptionDescription,
-					descriptionLocalizations: typeOptionDescriptionLocalizations,
+					description: typeOptionDescription["en-US"],
+					descriptionLocalizations: typeOptionDescription,
 					required: true,
 					choices: Object.keys(bindings).map<[string, Binding]>((bindingName: string): [string, Binding] => {
 						const binding: Binding = bindings[bindingName as keyof typeof bindings] as Binding;
@@ -79,8 +57,8 @@ const rawCommand: Command = {
 				{
 					type: "INTEGER",
 					name: identifierOptionName,
-					description: identifierOptionDescription,
-					descriptionLocalizations: identifierOptionDescriptionLocalizations,
+					description: identifierOptionDescription["en-US"],
+					descriptionLocalizations: identifierOptionDescription,
 					required: true,
 					minValue: 0,
 				},
@@ -137,10 +115,10 @@ const rawCommand: Command = {
 					return commandName;
 				},
 				typeOptionDescription: (): string => {
-					return typeOptionDescriptionLocalizations[locale];
+					return typeOptionDescription[locale];
 				},
 				identifierOptionDescription: (): string => {
-					return identifierOptionDescriptionLocalizations[locale];
+					return identifierOptionDescription[locale];
 				},
 			};
 		}));

--- a/src/commands/roadmap.ts
+++ b/src/commands/roadmap.ts
@@ -5,49 +5,31 @@ import type {
 	Interaction,
 } from "discord.js";
 import type Command from "../commands.js";
+import type {Roadmap as RoadmapCompilation} from "../compilations.js";
+import type {Roadmap as RoadmapDefinition} from "../definitions.js";
+import type {Roadmap as RoadmapDependency} from "../dependencies.js";
 import type {Locale, Localized} from "../utils/string.js";
-import {Util} from "discord.js";
-import {compileAll, composeAll, localize, resolve} from "../utils/string.js";
-type HelpGroups = {
-	commandName: () => string,
-};
-type ReplyGroups = {
-	intent: () => string,
-	link: () => string,
-};
-type IntentWithChannelGroups = {
-	channel: () => string,
-};
-type IntentWithoutChannelGroups = {};
-const commandName: string = "roadmap";
-const commandDescriptionLocalizations: Localized<string> = {
-	"en-US": "Tells you where to check the upcoming milestones of the game",
-	"fr": "Te dit où consulter les futurs jalons du jeu",
-};
-const commandDescription: string = commandDescriptionLocalizations["en-US"];
+import {roadmap as roadmapCompilation} from "../compilations.js";
+import {roadmap as roadmapDefinition} from "../definitions.js";
+import {composeAll, localize, resolve} from "../utils/string.js";
+type HelpGroups = RoadmapDependency["help"];
+const {
+	commandName,
+	commandDescription,
+}: RoadmapDefinition = roadmapDefinition;
+const {
+	help: helpLocalizations,
+	reply: replyLocalizations,
+	intentWithChannel: intentWithChannelLocalizations,
+	intentWithoutChannel: intentWithoutChannelLocalizations,
+}: RoadmapCompilation = roadmapCompilation;
 const link: string = "https://trello.com/b/3DPL9CwV/sba-to-do-list";
-const helpLocalizations: Localized<(groups: HelpGroups) => string> = compileAll<HelpGroups>({
-	"en-US": "Type `/$<commandName>` to know where to check the upcoming milestones of the game",
-	"fr": "Tape `/$<commandName>` pour savoir où consulter les futurs jalons du jeu",
-});
-const replyLocalizations: Localized<(groups: ReplyGroups) => string> = compileAll<ReplyGroups>({
-	"en-US": "$<intent> check upcoming milestones of the game [there](<$<link>>).",
-	"fr": "$<intent> consulter de futurs jalons du jeu [là](<$<link>>).",
-});
-const intentWithChannelLocalizations: Localized<(groups: IntentWithChannelGroups) => string> = compileAll<IntentWithChannelGroups>({
-	"en-US": "Before suggesting an idea in $<channel>, you can",
-	"fr": "Avant de suggérer une idée dans $<channel>, tu peux",
-});
-const intentWithoutChannelLocalizations: Localized<(groups: IntentWithoutChannelGroups) => string> = compileAll<IntentWithoutChannelGroups>({
-	"en-US": "You can",
-	"fr": "Tu peux",
-});
 const roadmapCommand: Command = {
 	register(): ApplicationCommandData {
 		return {
 			name: commandName,
-			description: commandDescription,
-			descriptionLocalizations: commandDescriptionLocalizations,
+			description: commandDescription["en-US"],
+			descriptionLocalizations: commandDescription,
 		};
 	},
 	async execute(interaction: Interaction): Promise<void> {

--- a/src/commands/soundtrack.ts
+++ b/src/commands/soundtrack.ts
@@ -5,25 +5,18 @@ import type {
 } from "discord.js";
 import type {Response} from "node-fetch";
 import type Command from "../commands.js";
+import type {Soundtrack as SoundtrackCompilation} from "../compilations.js";
+import type {Soundtrack as SoundtrackDefinition} from "../definitions.js";
+import type {Soundtrack as SoundtrackDependency} from "../dependencies.js";
 import type {Locale, Localized} from "../utils/string.js";
 import {Util} from "discord.js";
 import {JSDOM} from "jsdom";
 import fetch from "node-fetch";
-import {compileAll, composeAll, list, localize, resolve} from "../utils/string.js";
-type HelpGroups = {
-	commandName: () => string,
-};
-type ReplyGroups = {
-	linkList: () => string,
-};
-type DefaultReplyGroups = {
-	link: () => string,
-};
-type LinkGroups = {
-	title: () => string,
-	link: () => string,
-	views: () => string,
-};
+import {soundtrack as soundtrackCompilation} from "../compilations.js";
+import {soundtrack as soundtrackDefinition} from "../definitions.js";
+import {composeAll, list, localize, resolve} from "../utils/string.js";
+type HelpGroups = SoundtrackDependency["help"];
+type LinkGroups = SoundtrackDependency["link"];
 type Data = {
 	title: string,
 	link: string,
@@ -32,12 +25,16 @@ type Data = {
 type Patch = {
 	[k in string]: string
 };
-const commandName: string = "soundtrack";
-const commandDescriptionLocalizations: Localized<string> = {
-	"en-US": "Tells you where to listen to official music pieces of the game",
-	"fr": "Te dit où écouter des morceaux de musique officiels du jeu",
-};
-const commandDescription: string = commandDescriptionLocalizations["en-US"];
+const {
+	commandName,
+	commandDescription,
+}: SoundtrackDefinition = soundtrackDefinition;
+const {
+	help: helpLocalizations,
+	reply: replyLocalizations,
+	defaultReply: defaultReplyLocalizations,
+	link: linkLocalizations,
+}: SoundtrackCompilation = soundtrackCompilation;
 const titlePattern: RegExp = /^Super Bear Adventure - (.*) \(Original Soundtrack\)$/su;
 const viewsPatch: Patch = {
 	"No views": "0 views",
@@ -45,22 +42,6 @@ const viewsPatch: Patch = {
 };
 const viewsPattern: RegExp = /^(.*) views$/su;
 const link: string = "https://www.youtube.com/playlist?list=PLDF2V3x1AdQBnalWW0q69H5LF1-wgAxN8";
-const helpLocalizations: Localized<(groups: HelpGroups) => string> = compileAll<HelpGroups>({
-	"en-US": "Type `/$<commandName>` to know where to listen to official music pieces of the game",
-	"fr": "Tape `/$<commandName>` pour savoir où écouter des morceaux de musique officiels du jeu",
-});
-const replyLocalizations: Localized<(groups: ReplyGroups) => string> = compileAll<ReplyGroups>({
-	"en-US": "You can listen to official music pieces of the game there:\n$<linkList>",
-	"fr": "Tu peux écouter des morceaux de musique officiels du jeu là :\n$<linkList>",
-});
-const defaultReplyLocalizations: Localized<(groups: DefaultReplyGroups) => string> = compileAll<DefaultReplyGroups>({
-	"en-US": "You can listen to official music pieces of the game [there](<$<link>>).",
-	"fr": "Tu peux écouter des morceaux de musique officiels du jeu [là](<$<link>>).",
-});
-const linkLocalizations: Localized<((groups: LinkGroups) => string)> = compileAll<LinkGroups>({
-	"en-US": "[*$<title>* soundtrack](<$<link>>) (*$<views>* views)",
-	"fr": "[Bande-son *$<title>*](<$<link>>) (*$<views>* vues)",
-});
 function patch(text: string, table: Patch): string {
 	if (!(text in table)) {
 		return text;
@@ -71,8 +52,8 @@ const soundtrackCommand: Command = {
 	register(): ApplicationCommandData {
 		return {
 			name: commandName,
-			description: commandDescription,
-			descriptionLocalizations: commandDescriptionLocalizations,
+			description: commandDescription["en-US"],
+			descriptionLocalizations: commandDescription,
 		};
 	},
 	async execute(interaction: Interaction): Promise<void> {

--- a/src/commands/store.ts
+++ b/src/commands/store.ts
@@ -4,29 +4,29 @@ import type {
 	Interaction,
 } from "discord.js";
 import type Command from "../commands.js";
+import type {Store as StoreCompilation} from "../compilations.js";
+import type {Store as StoreDefinition} from "../definitions.js";
+import type {Store as StoreDependency} from "../dependencies.js";
 import type {Locale, Localized} from "../utils/string.js";
 import {Util} from "discord.js";
-import {compileAll, composeAll, list, localize, resolve} from "../utils/string.js";
-type HelpGroups = {
-	commandName: () => string,
-};
-type ReplyGroups = {
-	linkList: () => string,
-};
-type LinkGroups = {
-	title: () => string,
-	link: () => string,
-};
+import {store as storeCompilation} from "../compilations.js";
+import {store as storeDefinition} from "../definitions.js";
+import {composeAll, list, localize, resolve} from "../utils/string.js";
+type HelpGroups = StoreDependency["help"];
+type LinkGroups = StoreDependency["link"];
 type Data = {
 	title: Localized<string>,
 	link: string,
 };
-const commandName: string = "store";
-const commandDescriptionLocalizations: Localized<string> = {
-	"en-US": "Tells you where to buy offical products of the game",
-	"fr": "Te dit où acheter des produits officiels du jeu",
-};
-const commandDescription: string = commandDescriptionLocalizations["en-US"];
+const {
+	commandName,
+	commandDescription,
+}: StoreDefinition = storeDefinition;
+const {
+	help: helpLocalizations,
+	reply: replyLocalizations,
+	link: linkLocalizations,
+}: StoreCompilation = storeCompilation;
 const data: Data[] = [
 	{
 		title: {
@@ -43,24 +43,12 @@ const data: Data[] = [
 		link: "https://superbearadventure.myspreadshop.com/",
 	},
 ];
-const helpLocalizations: Localized<(groups: HelpGroups) => string> = compileAll<HelpGroups>({
-	"en-US": "Type `/$<commandName>` to know where to buy offical products of the game",
-	"fr": "Tape `/$<commandName>` pour savoir où acheter des produits officiels du jeu",
-});
-const replyLocalizations: Localized<(groups: ReplyGroups) => string> = compileAll<ReplyGroups>({
-	"en-US": "You can buy official products of the game there:\n$<linkList>",
-	"fr": "Tu peux acheter des produits officiels du jeu là :\n$<linkList>",
-});
-const linkLocalizations: Localized<((groups: LinkGroups) => string)> = compileAll<LinkGroups>({
-	"en-US": "[$<title> store](<$<link>>)",
-	"fr": "[Magasin $<title>](<$<link>>)",
-});
 const storeCommand: Command = {
 	register(): ApplicationCommandData {
 		return {
 			name: commandName,
-			description: commandDescription,
-			descriptionLocalizations: commandDescriptionLocalizations,
+			description: commandDescription["en-US"],
+			descriptionLocalizations: commandDescription,
 		};
 	},
 	async execute(interaction: Interaction): Promise<void> {

--- a/src/commands/tracker.ts
+++ b/src/commands/tracker.ts
@@ -5,34 +5,31 @@ import type {
 	Interaction,
 } from "discord.js";
 import type Command from "../commands.js";
+import type {Tracker as TrackerCompilation} from "../compilations.js";
+import type {Tracker as TrackerDefinition} from "../definitions.js";
+import type {Tracker as TrackerDependency} from "../dependencies.js";
 import type {Locale, Localized} from "../utils/string.js";
 import {Util} from "discord.js";
-import {compileAll, composeAll, list, localize, resolve} from "../utils/string.js";
-type HelpGroups = {
-	commandName: () => string,
-};
-type ReplyGroups = {
-	intent: () => string,
-	linkList: () => string,
-};
-type IntentWithChannelGroups = {
-	channel: () => string,
-};
-type IntentWithoutChannelGroups = {};
-type LinkGroups = {
-	title: () => string,
-	link: () => string,
-};
+import {tracker as trackerCompilation} from "../compilations.js";
+import {tracker as trackerDefinition} from "../definitions.js";
+import {composeAll, list, localize, resolve} from "../utils/string.js";
+type HelpGroups = TrackerDependency["help"];
+type LinkGroups = TrackerDependency["link"];
 type Data = {
 	title: Localized<string>,
 	link: string,
 };
-const commandName: string = "tracker";
-const commandDescriptionLocalizations: Localized<string> = {
-	"en-US": "Tells you where to check known bugs of the game",
-	"fr": "Te dit où consulter des bogues connus du jeu",
-};
-const commandDescription: string = commandDescriptionLocalizations["en-US"];
+const {
+	commandName,
+	commandDescription,
+}: TrackerDefinition = trackerDefinition;
+const {
+	help: helpLocalizations,
+	reply: replyLocalizations,
+	intentWithChannel: intentWithChannelLocalizations,
+	intentWithoutChannel: intentWithoutChannelLocalizations,
+	link: linkLocalizations,
+}: TrackerCompilation = trackerCompilation;
 const data: Data[] = [
 	{
 		title: {
@@ -49,32 +46,12 @@ const data: Data[] = [
 		link: "https://trello.com/b/yTojOuqv/super-bear-adventure-bugs",
 	},
 ];
-const helpLocalizations: Localized<(groups: HelpGroups) => string> = compileAll<HelpGroups>({
-	"en-US": "Type `/$<commandName>` to know where to check known bugs of the game",
-	"fr": "Tape `/$<commandName>` pour savoir où consulter des bogues connus du jeu",
-});
-const replyLocalizations: Localized<(groups: ReplyGroups) => string> = compileAll<ReplyGroups>({
-	"en-US": "$<intent> check the known bugs of the game there:\n$<linkList>",
-	"fr": "$<intent> consulter des bogues connus du jeu là :\n$<linkList>",
-});
-const intentWithChannelLocalizations: Localized<(groups: IntentWithChannelGroups) => string> = compileAll<IntentWithChannelGroups>({
-	"en-US": "Before reporting a bug in $<channel>, you can",
-	"fr": "Avant de rapporter un bogue dans $<channel>, tu peux",
-});
-const intentWithoutChannelLocalizations: Localized<(groups: IntentWithoutChannelGroups) => string> = compileAll<IntentWithoutChannelGroups>({
-	"en-US": "You can",
-	"fr": "Tu peux",
-});
-const linkLocalizations: Localized<((groups: LinkGroups) => string)> = compileAll<LinkGroups>({
-	"en-US": "[$<title> tracker](<$<link>>)",
-	"fr": "[Suivi $<title>](<$<link>>)",
-});
 const trackerCommand: Command = {
 	register(): ApplicationCommandData {
 		return {
 			name: commandName,
-			description: commandDescription,
-			descriptionLocalizations: commandDescriptionLocalizations,
+			description: commandDescription["en-US"],
+			descriptionLocalizations: commandDescription,
 		};
 	},
 	async execute(interaction: Interaction): Promise<void> {

--- a/src/commands/trailer.ts
+++ b/src/commands/trailer.ts
@@ -5,25 +5,18 @@ import type {
 } from "discord.js";
 import type {Response} from "node-fetch";
 import type Command from "../commands.js";
+import type {Trailer as TrailerCompilation} from "../compilations.js";
+import type {Trailer as TrailerDefinition} from "../definitions.js";
+import type {Trailer as TrailerDependency} from "../dependencies.js";
 import type {Locale, Localized} from "../utils/string.js";
 import {Util} from "discord.js";
 import {JSDOM} from "jsdom";
 import fetch from "node-fetch";
-import {compileAll, composeAll, list, localize, resolve} from "../utils/string.js";
-type HelpGroups = {
-	commandName: () => string,
-};
-type ReplyGroups = {
-	linkList: () => string,
-};
-type DefaultReplyGroups = {
-	link: () => string,
-};
-type LinkGroups = {
-	title: () => string,
-	link: () => string,
-	views: () => string,
-};
+import {trailer as trailerCompilation} from "../compilations.js";
+import {trailer as trailerDefinition} from "../definitions.js";
+import {composeAll, list, localize, resolve} from "../utils/string.js";
+type HelpGroups = TrailerDependency["help"];
+type LinkGroups = TrailerDependency["link"];
 type Data = {
 	title: string,
 	link: string,
@@ -32,12 +25,16 @@ type Data = {
 type Patch = {
 	[k in string]: string
 };
-const commandName: string = "trailer";
-const commandDescriptionLocalizations: Localized<string> = {
-	"en-US": "Tells you where to watch official trailers of the game",
-	"fr": "Te dit où regarder des bandes-annonces officielles du jeu",
-};
-const commandDescription: string = commandDescriptionLocalizations["en-US"];
+const {
+	commandName,
+	commandDescription,
+}: TrailerDefinition = trailerDefinition;
+const {
+	help: helpLocalizations,
+	reply: replyLocalizations,
+	defaultReply: defaultReplyLocalizations,
+	link: linkLocalizations,
+}: TrailerCompilation = trailerCompilation;
 const titlePatch: Patch = {
 	"Super Bear Adventure - Official Game Trailer": "Super Bear Adventure - Graphics Update Trailer"
 };
@@ -48,22 +45,6 @@ const viewsPatch: Patch = {
 };
 const viewsPattern: RegExp = /^(.*) views$/su;
 const link: string = "https://www.youtube.com/playlist?list=PLEJBkn30KcVVuA8Z0s_NLruYrbvzV5ieK";
-const helpLocalizations: Localized<(groups: HelpGroups) => string> = compileAll<HelpGroups>({
-	"en-US": "Type `/$<commandName>` to know where to watch official trailers of the game",
-	"fr": "Tape `/$<commandName>` pour savoir où regarder des bandes-annonces officielles du jeu",
-});
-const replyLocalizations: Localized<(groups: ReplyGroups) => string> = compileAll<ReplyGroups>({
-	"en-US": "You can watch official trailers of the game there:\n$<linkList>",
-	"fr": "Tu peux regarder des bandes-annonces officielles du jeu là :\n$<linkList>",
-});
-const defaultReplyLocalizations: Localized<(groups: DefaultReplyGroups) => string> = compileAll<DefaultReplyGroups>({
-	"en-US": "You can watch official trailers of the game [there](<$<link>>).",
-	"fr": "Tu peux regarder des bandes-annonces officielles du jeu [là](<$<link>>).",
-});
-const linkLocalizations: Localized<((groups: LinkGroups) => string)> = compileAll<LinkGroups>({
-	"en-US": "[*$<title>* trailer](<$<link>>) (*$<views>* views)",
-	"fr": "[Bande-annonce *$<title>*](<$<link>>) (*$<views>* views)",
-});
 function patch(text: string, table: Patch): string {
 	if (!(text in table)) {
 		return text;
@@ -74,8 +55,8 @@ const trailerCommand: Command = {
 	register(): ApplicationCommandData {
 		return {
 			name: commandName,
-			description: commandDescription,
-			descriptionLocalizations: commandDescriptionLocalizations,
+			description: commandDescription["en-US"],
+			descriptionLocalizations: commandDescription,
 		};
 	},
 	async execute(interaction: Interaction): Promise<void> {

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -5,64 +5,44 @@ import type {
 } from "discord.js";
 import type {Response} from "node-fetch";
 import type Command from "../commands.js";
+import type {Update as UpdateCompilation} from "../compilations.js";
+import type {Update as UpdateDefinition} from "../definitions.js";
+import type {Update as UpdateDependency} from "../dependencies.js";
 import type {Locale, Localized} from "../utils/string.js";
 import {Util} from "discord.js";
 import {JSDOM} from "jsdom";
 import fetch from "node-fetch";
-import {compileAll, composeAll, list, localize, resolve} from "../utils/string.js";
-type HelpGroups = {
-	commandName: () => string,
-};
-type ReplyGroups = {
-	linkList: () => string,
-};
-type DefaultReplyGroups = {
-	linkList: () => string,
-};
-type LinkGroups = {
-	title: () => string,
-	link: () => string,
-	version: () => string,
-	date: () => string,
-};
+import {update as updateCompilation} from "../compilations.js";
+import {update as updateDefinition} from "../definitions.js";
+import {composeAll, list, localize, resolve} from "../utils/string.js";
+type HelpGroups = UpdateDependency["help"];
+type LinkGroups = UpdateDependency["link"];
 type Data = {
 	title: string,
 	link: string,
 	version: string,
 	date: Date,
 };
-const commandName: string = "update";
-const commandDescriptionLocalizations: Localized<string> = {
-	"en-US": "Tells you what is the latest update of the game",
-	"fr": "Te dit quelle est la dernière mise à jour du jeu",
-};
-const commandDescription: string = commandDescriptionLocalizations["en-US"];
+const {
+	commandName,
+	commandDescription,
+}: UpdateDefinition = updateDefinition;
+const {
+	help: helpLocalizations,
+	reply: replyLocalizations,
+	defaultReply: defaultReplyLocalizations,
+	link: linkLocalizations,
+}: UpdateCompilation = updateCompilation;
 const links: string[] = [
 	"[*Android*](<https://play.google.com/store/apps/details?id=com.Earthkwak.Platformer>)",
 	"[*iOS*](<https://apps.apple.com/app/id1531842415>)",
 ];
-const helpLocalizations: Localized<(groups: HelpGroups) => string> = compileAll<HelpGroups>({
-	"en-US": "Type `/$<commandName>` to know what is the latest update of the game",
-	"fr": "Tape `/$<commandName>` pour savoir quelle est la dernière mise à jour du jeu",
-});
-const replyLocalizations: Localized<(groups: ReplyGroups) => string> = compileAll<ReplyGroups>({
-	"en-US": "You can check and download the latest update of the game there:\n$<linkList>",
-	"fr": "Tu peux consulter et télécharger la dernière mise à jour du jeu là :\n$<linkList>",
-});
-const defaultReplyLocalizations: Localized<(groups: DefaultReplyGroups) => string> = compileAll<DefaultReplyGroups>({
-	"en-US": "You can check and download the latest update of the game there:\n$<linkList>",
-	"fr": "Tu peux consulter et télécharger la dernière mise à jour du jeu là :\n$<linkList>",
-});
-const linkLocalizations: Localized<((groups: LinkGroups) => string)> = compileAll<LinkGroups>({
-	"en-US": "[*$<title>* platform](<$<link>>) (*$<version>* version as of *$<date>*)",
-	"fr": "[Plateforme *$<title>*](<$<link>>) (version *$<version>* au *$<date>*)",
-});
 const updateCommand: Command = {
 	register(): ApplicationCommandData {
 		return {
 			name: commandName,
-			description: commandDescription,
-			descriptionLocalizations: commandDescriptionLocalizations,
+			description: commandDescription["en-US"],
+			descriptionLocalizations: commandDescription,
 		};
 	},
 	async execute(interaction: Interaction): Promise<void> {

--- a/src/compilations.ts
+++ b/src/compilations.ts
@@ -1,0 +1,96 @@
+import aboutCompilation from "./compilations/about.js";
+import bearCompilation from "./compilations/bear.js";
+import chatCompilation from "./compilations/chat.js";
+import countCompilation from "./compilations/count.js";
+import emojiCompilation from "./compilations/emoji.js";
+import helpCompilation from "./compilations/help.js";
+import leaderboardCompilation from "./compilations/leaderboard.js";
+import missionCompilation from "./compilations/mission.js";
+import outfitCompilation from "./compilations/outfit.js";
+import rawCompilation from "./compilations/raw.js";
+import recordCompilation from "./compilations/record.js";
+import roadmapCompilation from "./compilations/roadmap.js";
+import rule7Compilation from "./compilations/rule7.js";
+import soundtrackCompilation from "./compilations/soundtrack.js";
+import storeCompilation from "./compilations/store.js";
+import trackerCompilation from "./compilations/tracker.js";
+import trailerCompilation from "./compilations/trailer.js";
+import updateCompilation from "./compilations/update.js";
+type About = typeof aboutCompilation;
+type Bear = typeof bearCompilation;
+type Chat = typeof chatCompilation;
+type Count = typeof countCompilation;
+type Emoji = typeof emojiCompilation;
+type Help = typeof helpCompilation;
+type Leaderboard = typeof leaderboardCompilation;
+type Mission = typeof missionCompilation;
+type Outfit = typeof outfitCompilation;
+type Raw = typeof rawCompilation;
+type Record = typeof recordCompilation;
+type Roadmap = typeof roadmapCompilation;
+type Rule7 = typeof rule7Compilation;
+type Soundtrack = typeof soundtrackCompilation;
+type Store = typeof storeCompilation;
+type Tracker = typeof trackerCompilation;
+type Trailer = typeof trailerCompilation;
+type Update = typeof updateCompilation;
+type Compilation = About | Bear | Chat | Count | Emoji | Help | Leaderboard | Mission | Outfit | Raw | Record | Roadmap | Rule7 | Soundtrack | Store | Tracker | Trailer | Update;
+const about: About = aboutCompilation;
+const bear: Bear = bearCompilation;
+const chat: Chat = chatCompilation;
+const count: Count = countCompilation;
+const emoji: Emoji = emojiCompilation;
+const help: Help = helpCompilation;
+const leaderboard: Leaderboard = leaderboardCompilation;
+const mission: Mission = missionCompilation;
+const outfit: Outfit = outfitCompilation;
+const raw: Raw = rawCompilation;
+const record: Record = recordCompilation;
+const roadmap: Roadmap = roadmapCompilation;
+const rule7: Rule7 = rule7Compilation;
+const soundtrack: Soundtrack = soundtrackCompilation;
+const store: Store = storeCompilation;
+const tracker: Tracker = trackerCompilation;
+const trailer: Trailer = trailerCompilation;
+const update: Update = updateCompilation;
+export default Compilation;
+export type {
+	About,
+	Bear,
+	Chat,
+	Count,
+	Emoji,
+	Help,
+	Leaderboard,
+	Mission,
+	Outfit,
+	Raw,
+	Record,
+	Roadmap,
+	Rule7,
+	Soundtrack,
+	Store,
+	Tracker,
+	Trailer,
+	Update,
+};
+export {
+	about,
+	bear,
+	chat,
+	count,
+	emoji,
+	help,
+	leaderboard,
+	mission,
+	outfit,
+	raw,
+	record,
+	roadmap,
+	rule7,
+	soundtrack,
+	store,
+	tracker,
+	trailer,
+	update,
+};

--- a/src/compilations/about.ts
+++ b/src/compilations/about.ts
@@ -1,0 +1,17 @@
+import type {About} from "../dependencies.js";
+import type {Localized} from "../utils/string.js";
+import {about} from "../definitions.js";
+import {compileAll} from "../utils/string.js";
+type HelpLocalizations = Localized<(groups: About["help"]) => string>;
+type ReplyLocalizations = Localized<(groups: About["reply"]) => string>;
+type AboutCompilation = {
+	help: HelpLocalizations,
+	reply: ReplyLocalizations,
+};
+const helpLocalizations: HelpLocalizations = compileAll<About["help"]>(about["help"]);
+const replyLocalizations: ReplyLocalizations = compileAll<About["reply"]>(about["reply"]);
+const aboutCompilation: AboutCompilation = {
+	help: helpLocalizations,
+	reply: replyLocalizations,
+};
+export default aboutCompilation;

--- a/src/compilations/bear.ts
+++ b/src/compilations/bear.ts
@@ -1,0 +1,43 @@
+import type {Bear} from "../dependencies.js";
+import type {Localized} from "../utils/string.js";
+import {bear} from "../definitions.js";
+import {compileAll} from "../utils/string.js";
+type HelpLocalizations = Localized<(groups: Bear["help"]) => string>;
+type ReplyLocalizations = Localized<(groups: Bear["reply"]) => string>;
+type NoOutfitLocalizations = Localized<(groups: Bear["noOutfit"]) => string>;
+type BossGoalLocalizations = Localized<(groups: Bear["bossGoal"]) => string>;
+type CoinsGoalLocalizations = Localized<(groups: Bear["coinsGoal"]) => string>;
+type TimeGoalLocalizations = Localized<(groups: Bear["timeGoal"]) => string>;
+type NoGoalLocalizations = Localized<(groups: Bear["noGoal"]) => string>;
+type BearCompilation = {
+	help: HelpLocalizations,
+	reply: ReplyLocalizations,
+	noOutfit: NoOutfitLocalizations,
+	bossGoal: BossGoalLocalizations,
+	coinsWithBossGoal: CoinsGoalLocalizations,
+	coinsWithoutBossGoal: CoinsGoalLocalizations,
+	timeWithBossOrCoinsGoal: TimeGoalLocalizations,
+	timeWithoutBossAndCoinsGoal: TimeGoalLocalizations,
+	noGoal: NoGoalLocalizations,
+};
+const helpLocalizations: HelpLocalizations = compileAll<Bear["help"]>(bear["help"]);
+const replyLocalizations: ReplyLocalizations = compileAll<Bear["reply"]>(bear["reply"]);
+const noOutfitLocalizations: NoOutfitLocalizations = compileAll<Bear["noOutfit"]>(bear["noOutfit"]);
+const bossGoalLocalizations: BossGoalLocalizations = compileAll<Bear["bossGoal"]>(bear["bossGoal"]);
+const coinsWithBossGoalLocalizations:  CoinsGoalLocalizations = compileAll<Bear["coinsGoal"]>(bear["coinsWithBossGoal"]);
+const coinsWithoutBossGoalLocalizations:  CoinsGoalLocalizations = compileAll<Bear["coinsGoal"]>(bear["coinsWithoutBossGoal"]);
+const timeWithBossOrCoinsGoalLocalizations: TimeGoalLocalizations = compileAll<Bear["timeGoal"]>(bear["timeWithBossOrCoinsGoal"]);
+const timeWithoutBossAndCoinsGoalLocalizations: TimeGoalLocalizations = compileAll<Bear["timeGoal"]>(bear["timeWithoutBossAndCoinsGoal"]);
+const noGoalLocalizations: NoGoalLocalizations = compileAll<Bear["noGoal"]>(bear["noGoal"]);
+const bearCompilation: BearCompilation = {
+	help: helpLocalizations,
+	reply: replyLocalizations,
+	noOutfit: noOutfitLocalizations,
+	bossGoal: bossGoalLocalizations,
+	coinsWithBossGoal: coinsWithBossGoalLocalizations,
+	coinsWithoutBossGoal: coinsWithoutBossGoalLocalizations,
+	timeWithBossOrCoinsGoal: timeWithBossOrCoinsGoalLocalizations,
+	timeWithoutBossAndCoinsGoal: timeWithoutBossAndCoinsGoalLocalizations,
+	noGoal: noGoalLocalizations,
+};
+export default bearCompilation;

--- a/src/compilations/chat.ts
+++ b/src/compilations/chat.ts
@@ -1,0 +1,53 @@
+import type {Chat} from "../dependencies.js";
+import type {Localized} from "../utils/string.js";
+import {chat} from "../definitions.js";
+import {compileAll} from "../utils/string.js";
+type HelpLocalizations = Localized<(groups: Chat["help"]) => string>;
+type ReplyLocalizations = Localized<(groups: Chat["reply"]) => string>;
+type BareReplyLocalizations = Localized<(groups: Chat["bareReply"]) => string>;
+type NoPrivacyReplyLocalizations = Localized<(groups: Chat["noPrivacyReply"]) => string>;
+type NoChannelReplyLocalizations = Localized<(groups: Chat["noChannelReply"]) => string>;
+type NoMessageReplyLocalizations = Localized<(groups: Chat["noMessageReply"]) => string>;
+type NoPositionReplyLocalizations = Localized<(groups: Chat["noPositionReply"]) => string>;
+type NoContentOrAttachmentReplyLocalizations = Localized<(groups: Chat["noContentOrAttachmentReply"]) => string>;
+type NoInteractionReplyLocalizations = Localized<(groups: Chat["noInteractionReply"]) => string>;
+type NoPatchPermissionReplyLocalizations = Localized<(groups: Chat["noPatchPermissionReply"]) => string>;
+type NoPostPermissionReplyLocalizations = Localized<(groups: Chat["noPostPermissionReply"]) => string>;
+type ChatCompilation = {
+	help: HelpLocalizations,
+	reply: ReplyLocalizations,
+	bareReply: BareReplyLocalizations,
+	noPrivacyReply: NoPrivacyReplyLocalizations,
+	noChannelReply: NoChannelReplyLocalizations,
+	noMessageReply: NoMessageReplyLocalizations,
+	noPositionReply: NoPositionReplyLocalizations,
+	noContentOrAttachmentReply: NoContentOrAttachmentReplyLocalizations,
+	noInteractionReply: NoInteractionReplyLocalizations,
+	noPatchPermissionReply: NoPatchPermissionReplyLocalizations,
+	noPostPermissionReply: NoPostPermissionReplyLocalizations,
+};
+const helpLocalizations: HelpLocalizations = compileAll<Chat["help"]>(chat["help"]);
+const replyLocalizations: ReplyLocalizations = compileAll<Chat["reply"]>(chat["reply"]);
+const bareReplyLocalizations: BareReplyLocalizations = compileAll<Chat["bareReply"]>(chat["bareReply"]);
+const noPrivacyReplyLocalizations: NoPrivacyReplyLocalizations = compileAll<Chat["noPrivacyReply"]>(chat["noPrivacyReply"]);
+const noChannelReplyLocalizations: NoChannelReplyLocalizations = compileAll<Chat["noChannelReply"]>(chat["noChannelReply"]);
+const noMessageReplyLocalizations: NoMessageReplyLocalizations = compileAll<Chat["noMessageReply"]>(chat["noMessageReply"]);
+const noPositionReplyLocalizations: NoPositionReplyLocalizations = compileAll<Chat["noPositionReply"]>(chat["noPositionReply"]);
+const noInteractionReplyLocalizations: NoInteractionReplyLocalizations = compileAll<Chat["noInteractionReply"]>(chat["noInteractionReply"]);
+const noContentOrAttachmentReplyLocalizations: NoContentOrAttachmentReplyLocalizations = compileAll<Chat["noContentOrAttachmentReply"]>(chat["noContentOrAttachmentReply"]);
+const noPatchPermissionReplyLocalizations: NoPatchPermissionReplyLocalizations = compileAll<Chat["noPatchPermissionReply"]>(chat["noPatchPermissionReply"]);
+const noPostPermissionReplyLocalizations: NoPostPermissionReplyLocalizations = compileAll<Chat["noPostPermissionReply"]>(chat["noPostPermissionReply"]);
+const chatCompilation: ChatCompilation = {
+	help: helpLocalizations,
+	reply: replyLocalizations,
+	bareReply: bareReplyLocalizations,
+	noPrivacyReply: noPrivacyReplyLocalizations,
+	noChannelReply: noChannelReplyLocalizations,
+	noMessageReply: noMessageReplyLocalizations,
+	noPositionReply: noPositionReplyLocalizations,
+	noContentOrAttachmentReply: noContentOrAttachmentReplyLocalizations,
+	noInteractionReply: noInteractionReplyLocalizations,
+	noPatchPermissionReply: noPatchPermissionReplyLocalizations,
+	noPostPermissionReply: noPostPermissionReplyLocalizations,
+};
+export default chatCompilation;

--- a/src/compilations/count.ts
+++ b/src/compilations/count.ts
@@ -1,0 +1,17 @@
+import type {Count} from "../dependencies.js";
+import type {Localized} from "../utils/string.js";
+import {count} from "../definitions.js";
+import {compileAll} from "../utils/string.js";
+type HelpLocalizations = Localized<(groups: Count["help"]) => string>;
+type ReplyLocalizations = Localized<(groups: Count["reply"]) => string>;
+type CountCompilation = {
+	help: HelpLocalizations,
+	reply: ReplyLocalizations,
+};
+const helpLocalizations: HelpLocalizations = compileAll<Count["help"]>(count["help"]);
+const replyLocalizations: ReplyLocalizations = compileAll<Count["reply"]>(count["reply"]);
+const countCompilation: CountCompilation = {
+	help: helpLocalizations,
+	reply: replyLocalizations,
+};
+export default countCompilation;

--- a/src/compilations/emoji.ts
+++ b/src/compilations/emoji.ts
@@ -1,0 +1,17 @@
+import type {Emoji} from "../dependencies.js";
+import type {Localized} from "../utils/string.js";
+import {emoji} from "../definitions.js";
+import {compileAll} from "../utils/string.js";
+type HelpLocalizations = Localized<(groups: Emoji["help"]) => string>;
+type NoPrivacyReplyLocalizations = Localized<(groups: Emoji["noPrivacyReply"]) => string>;
+type EmojiCompilation = {
+	help: HelpLocalizations,
+	noPrivacyReply: NoPrivacyReplyLocalizations,
+};
+const helpLocalizations: HelpLocalizations = compileAll<Emoji["help"]>(emoji["help"]);
+const noPrivacyReplyLocalizations: NoPrivacyReplyLocalizations = compileAll<Emoji["noPrivacyReply"]>(emoji["noPrivacyReply"]);
+const emojiCompilation: EmojiCompilation = {
+	help: helpLocalizations,
+	noPrivacyReply: noPrivacyReplyLocalizations,
+};
+export default emojiCompilation;

--- a/src/compilations/help.ts
+++ b/src/compilations/help.ts
@@ -1,0 +1,17 @@
+import type {Help} from "../dependencies.js";
+import type {Localized} from "../utils/string.js";
+import {help} from "../definitions.js";
+import {compileAll} from "../utils/string.js";
+type HelpLocalizations = Localized<(groups: Help["help"]) => string>;
+type ReplyLocalizations = Localized<(groups: Help["reply"]) => string>;
+type HelpCompilation = {
+	help: HelpLocalizations,
+	reply: ReplyLocalizations,
+};
+const helpLocalizations: HelpLocalizations = compileAll<Help["help"]>(help["help"]);
+const replyLocalizations: ReplyLocalizations = compileAll<Help["reply"]>(help["reply"]);
+const helpCompilation: HelpCompilation = {
+	help: helpLocalizations,
+	reply: replyLocalizations,
+};
+export default helpCompilation;

--- a/src/compilations/leaderboard.ts
+++ b/src/compilations/leaderboard.ts
@@ -1,0 +1,21 @@
+import type {Leaderboard} from "../dependencies.js";
+import type {Localized} from "../utils/string.js";
+import {leaderboard} from "../definitions.js";
+import {compileAll} from "../utils/string.js";
+type HelpLocalizations = Localized<(groups: Leaderboard["help"]) => string>;
+type ReplyLocalizations = Localized<(groups: Leaderboard["reply"]) => string>;
+type LinkLocalizations = Localized<(groups: Leaderboard["link"]) => string>;
+type LeaderboardCompilation = {
+	help: HelpLocalizations,
+	reply: ReplyLocalizations,
+	link: LinkLocalizations,
+};
+const helpLocalizations: HelpLocalizations = compileAll<Leaderboard["help"]>(leaderboard["help"]);
+const replyLocalizations: ReplyLocalizations = compileAll<Leaderboard["reply"]>(leaderboard["reply"]);
+const linkLocalizations: LinkLocalizations = compileAll<Leaderboard["link"]>(leaderboard["link"]);
+const leaderboardCompilation: LeaderboardCompilation = {
+	help: helpLocalizations,
+	reply: replyLocalizations,
+	link: linkLocalizations,
+};
+export default leaderboardCompilation;

--- a/src/compilations/mission.ts
+++ b/src/compilations/mission.ts
@@ -1,0 +1,33 @@
+import type {Mission} from "../dependencies.js";
+import type {Localized} from "../utils/string.js";
+import {mission} from "../definitions.js";
+import {compileAll} from "../utils/string.js";
+type HelpLocalizations = Localized<(groups: Mission["help"]) => string>;
+type ReplyLocalizations = Localized<(groups: Mission["reply"]) => string>;
+type BareReplyLocalizations = Localized<(groups: Mission["bareReply"]) => string>;
+type MissionNameLocalizations = Localized<(groups: Mission["missionName"]) => string>;
+type ScheduleLocalizations = Localized<(groups: Mission["schedule"]) => string>;
+type BareScheduleLocalizations = Localized<(groups: Mission["bareSchedule"]) => string>;
+type MissionCompilation = {
+	help: HelpLocalizations,
+	reply: ReplyLocalizations,
+	bareReply: BareReplyLocalizations,
+	missionName: MissionNameLocalizations,
+	schedule: ScheduleLocalizations,
+	bareSchedule: BareScheduleLocalizations,
+};
+const helpLocalizations: HelpLocalizations = compileAll<Mission["help"]>(mission["help"]);
+const replyLocalizations: ReplyLocalizations = compileAll<Mission["reply"]>(mission["reply"]);
+const bareReplyLocalizations: BareReplyLocalizations = compileAll<Mission["bareReply"]>(mission["bareReply"]);
+const missionNameLocalizations: MissionNameLocalizations = compileAll<Mission["missionName"]>(mission["missionName"]);
+const scheduleLocalizations: ScheduleLocalizations = compileAll<Mission["schedule"]>(mission["schedule"]);
+const bareScheduleLocalizations: BareScheduleLocalizations = compileAll<Mission["bareSchedule"]>(mission["bareSchedule"]);
+const missionCompilation: MissionCompilation = {
+	help: helpLocalizations,
+	reply: replyLocalizations,
+	bareReply: bareReplyLocalizations,
+	missionName: missionNameLocalizations,
+	schedule: scheduleLocalizations,
+	bareSchedule: bareScheduleLocalizations,
+};
+export default missionCompilation;

--- a/src/compilations/outfit.ts
+++ b/src/compilations/outfit.ts
@@ -1,0 +1,45 @@
+import type {Outfit} from "../dependencies.js";
+import type {Localized} from "../utils/string.js";
+import {outfit} from "../definitions.js";
+import {compileAll} from "../utils/string.js";
+type HelpLocalizations = Localized<(groups: Outfit["help"]) => string>;
+type ReplyLocalizations = Localized<(groups: Outfit["reply"]) => string>;
+type BareReplyLocalizations = Localized<(groups: Outfit["bareReply"]) => string>;
+type NoSlotReplyLocalizations = Localized<(groups: Outfit["noSlotReply"]) => string>;
+type TokensCostLocalizations = Localized<(groups: Outfit["tokensCost"]) => string>;
+type CoinsCostLocalizations = Localized<(groups: Outfit["coinsCost"]) => string>;
+type NoCostLocalizations = Localized<(groups: Outfit["noCost"]) => string>;
+type ScheduleLocalizations = Localized<(groups: Outfit["schedule"]) => string>;
+type BareScheduleLocalizations = Localized<(groups: Outfit["bareSchedule"]) => string>;
+type OutfitCompilation = {
+	help: HelpLocalizations,
+	reply: ReplyLocalizations,
+	bareReply: BareReplyLocalizations,
+	noSlotReply: NoSlotReplyLocalizations,
+	tokensCost: TokensCostLocalizations,
+	coinsCost: CoinsCostLocalizations,
+	noCost: NoCostLocalizations,
+	schedule: ScheduleLocalizations,
+	bareSchedule: BareScheduleLocalizations,
+};
+const helpLocalizations: HelpLocalizations = compileAll<Outfit["help"]>(outfit["help"]);
+const replyLocalizations: ReplyLocalizations = compileAll<Outfit["reply"]>(outfit["reply"]);
+const bareReplyLocalizations: BareReplyLocalizations = compileAll<Outfit["bareReply"]>(outfit["bareReply"]);
+const noSlotReplyLocalizations: NoSlotReplyLocalizations = compileAll<Outfit["noSlotReply"]>(outfit["noSlotReply"]);
+const tokensCostLocalizations: TokensCostLocalizations = compileAll<Outfit["tokensCost"]>(outfit["tokensCost"]);
+const coinsCostLocalizations: CoinsCostLocalizations = compileAll<Outfit["coinsCost"]>(outfit["coinsCost"]);
+const noCostLocalizations: NoCostLocalizations = compileAll<Outfit["noCost"]>(outfit["noCost"]);
+const scheduleLocalizations: ScheduleLocalizations = compileAll<Outfit["schedule"]>(outfit["schedule"]);
+const bareScheduleLocalizations: BareScheduleLocalizations = compileAll<Outfit["bareSchedule"]>(outfit["bareSchedule"]);
+const outfitCompilation: OutfitCompilation = {
+	help: helpLocalizations,
+	reply: replyLocalizations,
+	bareReply: bareReplyLocalizations,
+	noSlotReply: noSlotReplyLocalizations,
+	tokensCost: tokensCostLocalizations,
+	coinsCost: coinsCostLocalizations,
+	noCost: noCostLocalizations,
+	schedule: scheduleLocalizations,
+	bareSchedule: bareScheduleLocalizations,
+};
+export default outfitCompilation;

--- a/src/compilations/raw.ts
+++ b/src/compilations/raw.ts
@@ -1,0 +1,21 @@
+import type {Raw} from "../dependencies.js";
+import type {Localized} from "../utils/string.js";
+import {raw} from "../definitions.js";
+import {compileAll} from "../utils/string.js";
+type HelpLocalizations = Localized<(groups: Raw["help"]) => string>;
+type NoTypeReplyLocalizations = Localized<(groups: Raw["noTypeReply"]) => string>;
+type NoIdentifierReplyLocalizations = Localized<(groups: Raw["noIdentifierReply"]) => string>;
+type RawCompilation = {
+	help: HelpLocalizations,
+	noTypeReply: NoTypeReplyLocalizations,
+	noIdentifierReply: NoIdentifierReplyLocalizations,
+};
+const helpLocalizations: HelpLocalizations = compileAll<Raw["help"]>(raw["help"]);
+const noTypeReplyLocalizations: NoTypeReplyLocalizations = compileAll<Raw["noTypeReply"]>(raw["noTypeReply"]);
+const noIdentifierReplyLocalizations: NoIdentifierReplyLocalizations = compileAll<Raw["noIdentifierReply"]>(raw["noIdentifierReply"]);
+const rawCompilation: RawCompilation = {
+	help: helpLocalizations,
+	noTypeReply: noTypeReplyLocalizations,
+	noIdentifierReply: noIdentifierReplyLocalizations,
+};
+export default rawCompilation;

--- a/src/compilations/record.ts
+++ b/src/compilations/record.ts
@@ -1,0 +1,13 @@
+import type {Record} from "../dependencies.js";
+import type {Localized} from "../utils/string.js";
+import {record} from "../definitions.js";
+import {compileAll} from "../utils/string.js";
+type HelpLocalizations = Localized<(groups: Record["help"]) => string>;
+type RecordCompilation = {
+	help: HelpLocalizations,
+};
+const helpLocalizations: HelpLocalizations = compileAll<Record["help"]>(record["help"]);
+const recordCompilation: RecordCompilation = {
+	help: helpLocalizations,
+};
+export default recordCompilation;

--- a/src/compilations/roadmap.ts
+++ b/src/compilations/roadmap.ts
@@ -1,0 +1,26 @@
+
+import type {Roadmap} from "../dependencies.js";
+import type {Localized} from "../utils/string.js";
+import {roadmap} from "../definitions.js";
+import {compileAll} from "../utils/string.js";
+type HelpLocalizations = Localized<(groups: Roadmap["help"]) => string>;
+type ReplyLocalizations = Localized<(groups: Roadmap["reply"]) => string>;
+type IntentWithChannelLocalizations = Localized<(groups: Roadmap["intentWithChannel"]) => string>;
+type IntentWithoutChannelLocalizations = Localized<(groups: Roadmap["intentWithoutChannel"]) => string>;
+type RoadmapCompilation = {
+	help: HelpLocalizations,
+	reply: ReplyLocalizations,
+	intentWithChannel: IntentWithChannelLocalizations,
+	intentWithoutChannel: IntentWithoutChannelLocalizations,
+};
+const helpLocalizations: HelpLocalizations = compileAll<Roadmap["help"]>(roadmap["help"]);
+const replyLocalizations: ReplyLocalizations = compileAll<Roadmap["reply"]>(roadmap["reply"]);
+const intentWithChannelLocalizations: IntentWithChannelLocalizations = compileAll<Roadmap["intentWithChannel"]>(roadmap["intentWithChannel"]);
+const intentWithoutChannelLocalizations: IntentWithoutChannelLocalizations = compileAll<Roadmap["intentWithoutChannel"]>(roadmap["intentWithoutChannel"]);
+const roadmapCompilation: RoadmapCompilation = {
+	help: helpLocalizations,
+	reply: replyLocalizations,
+	intentWithChannel: intentWithChannelLocalizations,
+	intentWithoutChannel: intentWithoutChannelLocalizations,
+};
+export default roadmapCompilation;

--- a/src/compilations/rule7.ts
+++ b/src/compilations/rule7.ts
@@ -1,0 +1,13 @@
+import type {Rule7} from "../dependencies.js";
+import type {Localized} from "../utils/string.js";
+import {rule7} from "../definitions.js";
+import {compileAll} from "../utils/string.js";
+type HelpLocalizations = Localized<(groups: Rule7["help"]) => string>;
+type Rule7Compilation = {
+	help: HelpLocalizations,
+};
+const helpLocalizations: HelpLocalizations = compileAll<Rule7["help"]>(rule7["help"]);
+const rule7Compilation: Rule7Compilation = {
+	help: helpLocalizations,
+};
+export default rule7Compilation;

--- a/src/compilations/soundtrack.ts
+++ b/src/compilations/soundtrack.ts
@@ -1,0 +1,25 @@
+import type {Soundtrack} from "../dependencies.js";
+import type {Localized} from "../utils/string.js";
+import {soundtrack} from "../definitions.js";
+import {compileAll} from "../utils/string.js";
+type HelpLocalizations = Localized<(groups: Soundtrack["help"]) => string>;
+type ReplyLocalizations = Localized<(groups: Soundtrack["reply"]) => string>;
+type DefaultReplyLocalizations = Localized<(groups: Soundtrack["defaultReply"]) => string>;
+type LinkLocalizations = Localized<(groups: Soundtrack["link"]) => string>;
+type SoundtrackCompilation = {
+	help: HelpLocalizations,
+	reply: ReplyLocalizations,
+	defaultReply: DefaultReplyLocalizations,
+	link: LinkLocalizations,
+};
+const helpLocalizations: HelpLocalizations = compileAll<Soundtrack["help"]>(soundtrack["help"]);
+const replyLocalizations: ReplyLocalizations = compileAll<Soundtrack["reply"]>(soundtrack["reply"]);
+const defaultReplyLocalizations: DefaultReplyLocalizations = compileAll<Soundtrack["defaultReply"]>(soundtrack["defaultReply"]);
+const linkLocalizations: LinkLocalizations = compileAll<Soundtrack["link"]>(soundtrack["link"]);
+const soundtrackCompilation: SoundtrackCompilation = {
+	help: helpLocalizations,
+	reply: replyLocalizations,
+	defaultReply: defaultReplyLocalizations,
+	link: linkLocalizations,
+};
+export default soundtrackCompilation;

--- a/src/compilations/store.ts
+++ b/src/compilations/store.ts
@@ -1,0 +1,21 @@
+import type {Store} from "../dependencies.js";
+import type {Localized} from "../utils/string.js";
+import {store} from "../definitions.js";
+import {compileAll} from "../utils/string.js";
+type HelpLocalizations = Localized<(groups: Store["help"]) => string>;
+type ReplyLocalizations = Localized<(groups: Store["reply"]) => string>;
+type LinkLocalizations = Localized<(groups: Store["link"]) => string>;
+type StoreCompilation = {
+	help: HelpLocalizations,
+	reply: ReplyLocalizations,
+	link: LinkLocalizations,
+};
+const helpLocalizations: HelpLocalizations = compileAll<Store["help"]>(store["help"]);
+const replyLocalizations: ReplyLocalizations = compileAll<Store["reply"]>(store["reply"]);
+const linkLocalizations: LinkLocalizations = compileAll<Store["link"]>(store["link"]);
+const storeCompilation: StoreCompilation = {
+	help: helpLocalizations,
+	reply: replyLocalizations,
+	link: linkLocalizations,
+};
+export default storeCompilation;

--- a/src/compilations/tracker.ts
+++ b/src/compilations/tracker.ts
@@ -1,0 +1,30 @@
+
+import type {Tracker} from "../dependencies.js";
+import type {Localized} from "../utils/string.js";
+import {tracker} from "../definitions.js";
+import {compileAll} from "../utils/string.js";
+type HelpLocalizations = Localized<(groups: Tracker["help"]) => string>;
+type ReplyLocalizations = Localized<(groups: Tracker["reply"]) => string>;
+type IntentWithChannelLocalizations = Localized<(groups: Tracker["intentWithChannel"]) => string>;
+type IntentWithoutChannelLocalizations = Localized<(groups: Tracker["intentWithoutChannel"]) => string>;
+type LinkLocalizations = Localized<(groups: Tracker["link"]) => string>;
+type TrackerCompilation = {
+	help: HelpLocalizations,
+	reply: ReplyLocalizations,
+	intentWithChannel: IntentWithChannelLocalizations,
+	intentWithoutChannel: IntentWithoutChannelLocalizations,
+	link: LinkLocalizations,
+};
+const helpLocalizations: HelpLocalizations = compileAll<Tracker["help"]>(tracker["help"]);
+const replyLocalizations: ReplyLocalizations = compileAll<Tracker["reply"]>(tracker["reply"]);
+const intentWithChannelLocalizations: IntentWithChannelLocalizations = compileAll<Tracker["intentWithChannel"]>(tracker["intentWithChannel"]);
+const intentWithoutChannelLocalizations: IntentWithoutChannelLocalizations = compileAll<Tracker["intentWithoutChannel"]>(tracker["intentWithoutChannel"]);
+const linkLocalizations: LinkLocalizations = compileAll<Tracker["link"]>(tracker["link"]);
+const trackerCompilation: TrackerCompilation = {
+	help: helpLocalizations,
+	reply: replyLocalizations,
+	intentWithChannel: intentWithChannelLocalizations,
+	intentWithoutChannel: intentWithoutChannelLocalizations,
+	link: linkLocalizations,
+};
+export default trackerCompilation;

--- a/src/compilations/trailer.ts
+++ b/src/compilations/trailer.ts
@@ -1,0 +1,25 @@
+import type {Trailer} from "../dependencies.js";
+import type {Localized} from "../utils/string.js";
+import {trailer} from "../definitions.js";
+import {compileAll} from "../utils/string.js";
+type HelpLocalizations = Localized<(groups: Trailer["help"]) => string>;
+type ReplyLocalizations = Localized<(groups: Trailer["reply"]) => string>;
+type DefaultReplyLocalizations = Localized<(groups: Trailer["defaultReply"]) => string>;
+type LinkLocalizations = Localized<(groups: Trailer["link"]) => string>;
+type TrailerCompilation = {
+	help: HelpLocalizations,
+	reply: ReplyLocalizations,
+	defaultReply: DefaultReplyLocalizations,
+	link: LinkLocalizations,
+};
+const helpLocalizations: HelpLocalizations = compileAll<Trailer["help"]>(trailer["help"]);
+const replyLocalizations: ReplyLocalizations = compileAll<Trailer["reply"]>(trailer["reply"]);
+const defaultReplyLocalizations: DefaultReplyLocalizations = compileAll<Trailer["defaultReply"]>(trailer["defaultReply"]);
+const linkLocalizations: LinkLocalizations = compileAll<Trailer["link"]>(trailer["link"]);
+const trailerCompilation: TrailerCompilation = {
+	help: helpLocalizations,
+	reply: replyLocalizations,
+	defaultReply: defaultReplyLocalizations,
+	link: linkLocalizations,
+};
+export default trailerCompilation;

--- a/src/compilations/update.ts
+++ b/src/compilations/update.ts
@@ -1,0 +1,25 @@
+import type {Update} from "../dependencies.js";
+import type {Localized} from "../utils/string.js";
+import {update} from "../definitions.js";
+import {compileAll} from "../utils/string.js";
+type HelpLocalizations = Localized<(groups: Update["help"]) => string>;
+type ReplyLocalizations = Localized<(groups: Update["reply"]) => string>;
+type DefaultReplyLocalizations = Localized<(groups: Update["defaultReply"]) => string>;
+type LinkLocalizations = Localized<(groups: Update["link"]) => string>;
+type UpdateCompilation = {
+	help: HelpLocalizations,
+	reply: ReplyLocalizations,
+	defaultReply: DefaultReplyLocalizations,
+	link: LinkLocalizations,
+};
+const helpLocalizations: HelpLocalizations = compileAll<Update["help"]>(update["help"]);
+const replyLocalizations: ReplyLocalizations = compileAll<Update["reply"]>(update["reply"]);
+const defaultReplyLocalizations: DefaultReplyLocalizations = compileAll<Update["defaultReply"]>(update["defaultReply"]);
+const linkLocalizations: LinkLocalizations = compileAll<Update["link"]>(update["link"]);
+const updateCompilation: UpdateCompilation = {
+	help: helpLocalizations,
+	reply: replyLocalizations,
+	defaultReply: defaultReplyLocalizations,
+	link: linkLocalizations,
+};
+export default updateCompilation;

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -1,0 +1,254 @@
+import type {Localized} from "./utils/string.js";
+import aboutDefinition from "./definitions/about.json" assert {type: "json"};
+import bearDefinition from "./definitions/bear.json" assert {type: "json"};
+import chatDefinition from "./definitions/chat.json" assert {type: "json"};
+import countDefinition from "./definitions/count.json" assert {type: "json"};
+import emojiDefinition from "./definitions/emoji.json" assert {type: "json"};
+import helpDefinition from "./definitions/help.json" assert {type: "json"};
+import leaderboardDefinition from "./definitions/leaderboard.json" assert {type: "json"};
+import missionDefinition from "./definitions/mission.json" assert {type: "json"};
+import outfitDefinition from "./definitions/outfit.json" assert {type: "json"};
+import rawDefinition from "./definitions/raw.json" assert {type: "json"};
+import recordDefinition from "./definitions/record.json" assert {type: "json"};
+import roadmapDefinition from "./definitions/roadmap.json" assert {type: "json"};
+import rule7Definition from "./definitions/rule7.json" assert {type: "json"};
+import soundtrackDefinition from "./definitions/soundtrack.json" assert {type: "json"};
+import storeDefinition from "./definitions/store.json" assert {type: "json"};
+import trackerDefinition from "./definitions/tracker.json" assert {type: "json"};
+import trailerDefinition from "./definitions/trailer.json" assert {type: "json"};
+import updateDefinition from "./definitions/update.json" assert {type: "json"};
+type About = {
+	commandName: string,
+	commandDescription: Localized<string>,
+	help: Localized<string>,
+	reply: Localized<string>,
+};
+type Bear = {
+	commandName: string,
+	commandDescription: Localized<string>,
+	bearOptionName: string,
+	bearOptionDescription: Localized<string>,
+	help: Localized<string>,
+	reply: Localized<string>,
+	noOutfit: Localized<string>,
+	bossGoal: Localized<string>,
+	coinsWithBossGoal: Localized<string>,
+	coinsWithoutBossGoal: Localized<string>,
+	timeWithBossOrCoinsGoal: Localized<string>,
+	timeWithoutBossAndCoinsGoal: Localized<string>,
+	noGoal: Localized<string>,
+};
+type Chat = {
+	commandName: string,
+	commandDescription: Localized<string>,
+	postSubCommandName: string,
+	postSubCommandDescription: Localized<string>,
+	patchSubCommandName: string,
+	patchSubCommandDescription: Localized<string>,
+	attachSubCommandName: string,
+	attachSubCommandDescription: Localized<string>,
+	detachSubCommandName: string,
+	detachSubCommandDescription: Localized<string>,
+	channelOptionName: string,
+	channelOptionDescription: Localized<string>,
+	messageOptionName: string,
+	messageOptionDescription: Localized<string>,
+	contentOptionName: string,
+	contentOptionDescription: Localized<string>,
+	positionOptionName: string,
+	positionOptionDescription: Localized<string>,
+	attachmentOptionName: string,
+	attachmentOptionDescription: Localized<string>,
+	help: Localized<string>,
+	reply: Localized<string>,
+	bareReply: Localized<string>,
+	noPrivacyReply: Localized<string>,
+	noChannelReply: Localized<string>,
+	noMessageReply: Localized<string>,
+	noPositionReply: Localized<string>,
+	noInteractionReply: Localized<string>,
+	noContentOrAttachmentReply: Localized<string>,
+	noPatchPermissionReply: Localized<string>,
+	noPostPermissionReply: Localized<string>,
+};
+type Count = {
+	commandName: string,
+	commandDescription: Localized<string>,
+	help: Localized<string>,
+	reply: Localized<string>,
+};
+type Emoji = {
+	commandName: string,
+	commandDescription: Localized<string>,
+	baseOptionName: string,
+	baseOptionDescription: Localized<string>,
+	stylesOptionName: string,
+	stylesOptionDescription: Localized<string>,
+	help: Localized<string>,
+	noPrivacyReply: Localized<string>,
+};
+type Help = {
+	commandName: string,
+	commandDescription: Localized<string>,
+	help: Localized<string>,
+	reply: Localized<string>,
+};
+type Leaderboard = {
+	commandName: string,
+	commandDescription: Localized<string>,
+	help: Localized<string>,
+	reply: Localized<string>,
+	link: Localized<string>,
+};
+type Mission = {
+	commandName: string,
+	commandDescription: Localized<string>,
+	missionOptionName: string,
+	missionOptionDescription: Localized<string>,
+	help: Localized<string>,
+	reply: Localized<string>,
+	bareReply: Localized<string>,
+	missionName: Localized<string>,
+	schedule: Localized<string>,
+	bareSchedule: Localized<string>,
+};
+type Outfit = {
+	commandName: string,
+	commandDescription: Localized<string>,
+	outfitOptionName: string,
+	outfitOptionDescription: Localized<string>,
+	help: Localized<string>,
+	reply: Localized<string>,
+	bareReply: Localized<string>,
+	noSlotReply: Localized<string>,
+	tokensCost: Localized<string>,
+	coinsCost: Localized<string>,
+	noCost: Localized<string>,
+	schedule: Localized<string>,
+	bareSchedule: Localized<string>,
+};
+type Raw = {
+	commandName: string,
+	commandDescription: Localized<string>,
+	typeOptionName: string,
+	typeOptionDescription: Localized<string>,
+	identifierOptionName: string,
+	identifierOptionDescription: Localized<string>,
+	help: Localized<string>,
+	noTypeReply: Localized<string>,
+	noIdentifierReply: Localized<string>,
+};
+type Record = {
+	help: Localized<string>,
+};
+type Roadmap = {
+	commandName: string,
+	commandDescription: Localized<string>,
+	help: Localized<string>,
+	reply: Localized<string>,
+	intentWithChannel: Localized<string>,
+	intentWithoutChannel: Localized<string>,
+};
+type Rule7 = {
+	help: Localized<string>,
+};
+type Soundtrack = {
+	commandName: string,
+	commandDescription: Localized<string>,
+	help: Localized<string>,
+	reply: Localized<string>,
+	defaultReply: Localized<string>,
+	link: Localized<string>,
+};
+type Store = {
+	commandName: string,
+	commandDescription: Localized<string>,
+	help: Localized<string>,
+	reply: Localized<string>,
+	link: Localized<string>,
+};
+type Tracker = {
+	commandName: string,
+	commandDescription: Localized<string>,
+	help: Localized<string>,
+	reply: Localized<string>,
+	intentWithChannel: Localized<string>,
+	intentWithoutChannel: Localized<string>,
+	link: Localized<string>,
+};
+type Trailer = {
+	commandName: string,
+	commandDescription: Localized<string>,
+	help: Localized<string>,
+	reply: Localized<string>,
+	defaultReply: Localized<string>,
+	link: Localized<string>,
+};
+type Update = {
+	commandName: string,
+	commandDescription: Localized<string>,
+	help: Localized<string>,
+	reply: Localized<string>,
+	defaultReply: Localized<string>,
+	link: Localized<string>,
+};
+type Definition = About | Bear | Chat | Count | Emoji | Help | Leaderboard | Mission | Outfit | Raw | Record | Roadmap | Rule7 | Soundtrack | Store | Tracker | Trailer | Update;
+const about: About = aboutDefinition;
+const bear: Bear = bearDefinition;
+const chat: Chat = chatDefinition;
+const count: Count = countDefinition;
+const emoji: Emoji = emojiDefinition;
+const help: Help = helpDefinition;
+const leaderboard: Leaderboard = leaderboardDefinition;
+const mission: Mission = missionDefinition;
+const outfit: Outfit = outfitDefinition;
+const raw: Raw = rawDefinition;
+const record: Record = recordDefinition;
+const roadmap: Roadmap = roadmapDefinition;
+const rule7: Rule7 = rule7Definition;
+const soundtrack: Soundtrack = soundtrackDefinition;
+const store: Store = storeDefinition;
+const tracker: Tracker = trackerDefinition;
+const trailer: Trailer = trailerDefinition;
+const update: Update = updateDefinition;
+export default Definition;
+export type {
+	About,
+	Bear,
+	Chat,
+	Count,
+	Emoji,
+	Help,
+	Leaderboard,
+	Mission,
+	Outfit,
+	Raw,
+	Record,
+	Roadmap,
+	Rule7,
+	Soundtrack,
+	Store,
+	Tracker,
+	Trailer,
+	Update,
+};
+export {
+	about,
+	bear,
+	chat,
+	count,
+	emoji,
+	help,
+	leaderboard,
+	mission,
+	outfit,
+	raw,
+	record,
+	roadmap,
+	rule7,
+	soundtrack,
+	store,
+	tracker,
+	trailer,
+	update,
+};

--- a/src/definitions/about.json
+++ b/src/definitions/about.json
@@ -1,0 +1,15 @@
+{
+	"commandName": "about",
+	"commandDescription": {
+		"en-US": "Tells you where I come from",
+		"fr": "Te dit d'où je viens"
+	},
+	"help": {
+		"en-US": "Type `/$<commandName>` to know where I come from",
+		"fr": "Tape `/$<commandName>` pour savoir d'où je viens"
+	},
+	"reply": {
+		"en-US": "I am *$<bot>*, a bot made by *$<author>*, and I am open source!\nMy code is available [there](<$<link>>).",
+		"fr": "Je suis *$<bot>*, un robot fait par *$<author>*, et je suis open source !\nMon code est disponible [là](<$<link>>)."
+	}
+}

--- a/src/definitions/bear.json
+++ b/src/definitions/bear.json
@@ -1,0 +1,48 @@
+{
+	"commandName": "bear",
+	"commandDescription": {
+		"en-US": "Tells you who is this bear",
+		"fr": "Te dit qui est cet ours"
+	},
+	"bearOptionName": "bear",
+	"bearOptionDescription": {
+		"en-US": "Some bear",
+		"fr": "Un ours"
+	},
+	"help": {
+		"en-US": "Type `/$<commandName> $<bearOptionDescription>` to know who is `$<bearOptionDescription>`",
+		"fr": "Tape `/$<commandName> $<bearOptionDescription>` pour savoir qui est `$<bearOptionDescription>`"
+	},
+	"reply": {
+		"en-US": "**$<name>** has been imprisoned in **$<level>** and is wearing $<outfitNameConjunction>.\n$<goalConjunction>!",
+		"fr": "**$<name>** a été emprisonné·e dans **$<level>** et porte $<outfitNameConjunction>.\n$<goalConjunction> !"
+	},
+	"noOutfit": {
+		"en-US": "the bare minimum",
+		"fr": "le plus simple appareil"
+	},
+	"bossGoal": {
+		"en-US": "Beat **$<boss>**",
+		"fr": "Bats **$<boss>**"
+	},
+	"coinsWithBossGoal": {
+		"en-US": "collect **$<coins> coins**",
+		"fr": "collecte **$<coins> pièces**"
+	},
+	"coinsWithoutBossGoal": {
+		"en-US": "Collect **$<coins> coins**",
+		"fr": "Collecte **$<coins> pièces**"
+	},
+	"timeWithBossOrCoinsGoal": {
+		"en-US": "unlock the cage in less than **$<time>** to beat the gold time",
+		"fr": "déverrouille la cage en moins de **$<time>** pour battre le temps d'or"
+	},
+	"timeWithoutBossAndCoinsGoal": {
+		"en-US": "Unlock the cage in less than **$<time>** to beat the gold time",
+		"fr": "Déverrouille la cage en moins de **$<time>** pour battre le temps d'or"
+	},
+	"noGoal": {
+		"en-US": "Let's go",
+		"fr": "En route"
+	}
+}

--- a/src/definitions/chat.json
+++ b/src/definitions/chat.json
@@ -1,0 +1,96 @@
+{
+	"commandName": "chat",
+	"commandDescription": {
+		"en-US": "Sends this content with these attachments or edits this message with them in this channel",
+		"fr": "Envoie ce contenu avec ces pièces jointes ou modifie ce message avec ceux-là dans ce salon"
+	},
+	"postSubCommandName": "post",
+	"postSubCommandDescription": {
+		"en-US": "Sends this content in this channel",
+		"fr": "Envoie ce contenu dans ce salon"
+	},
+	"patchSubCommandName": "patch",
+	"patchSubCommandDescription": {
+		"en-US": "Edits this message with this content in this channel",
+		"fr": "Modifie de message avec ce contenu dans ce salon"
+	},
+	"attachSubCommandName": "attach",
+	"attachSubCommandDescription": {
+		"en-US": "Adds at this position this attachment to this message in this channel",
+		"fr": "Ajoute à cette position cette pièce jointe à ce message dans ce salon"
+	},
+	"detachSubCommandName": "detach",
+	"detachSubCommandDescription": {
+		"en-US": "Removes at this position the attachment from this message in this channel",
+		"fr": "Retire à cette position la pièce jointe de ce message dans ce salon"
+	},
+	"channelOptionName": "channel",
+	"channelOptionDescription": {
+		"en-US": "Some channel",
+		"fr": "Un salon"
+	},
+	"messageOptionName": "message",
+	"messageOptionDescription": {
+		"en-US": "Some message",
+		"fr": "Un message"
+	},
+	"contentOptionName": "content",
+	"contentOptionDescription": {
+		"en-US": "Some content",
+		"fr": "Un contenu"
+	},
+	"positionOptionName": "position",
+	"positionOptionDescription": {
+		"en-US": "Some position",
+		"fr": "Une position"
+	},
+	"attachmentOptionName": "attachment",
+	"attachmentOptionDescription": {
+		"en-US": "Some attachment",
+		"fr": "Une pièce jointe"
+	},
+	"help": {
+		"en-US": "Type `/$<commandName> $<postSubCommandName> $<channelOptionDescription> $<contentOptionDescription>` to send `$<contentOptionDescription>` in `$<channelOptionDescription>`\nType `/$<commandName> $<patchSubCommandName> $<channelOptionDescription> $<messageOptionDescription> $<contentOptionDescription>` to edit `$<messageOptionDescription>` with `$<contentOptionDescription>` in `$<channelOptionDescription>`\nType `/$<commandName> $<attachSubCommandName> $<channelOptionDescription> $<messageOptionDescription> $<positionOptionDescription> $<attachmentOptionDescription>` to add at `$<positionOptionDescription>` `$<attachmentOptionDescription>` to `$<messageOptionDescription>` in `$<channelOptionDescription>`\nType `/$<commandName> $<detachSubCommandName> $<channelOptionDescription> $<messageOptionDescription> $<positionOptionDescription>` to remove at `$<positionOptionDescription>` the attachment of `$<messageOptionDescription>` in `$<channelOptionDescription>`",
+		"fr": "Tape `/$<commandName> $<postSubCommandName> $<channelOptionDescription> $<contentOptionDescription>` pour envoyer `$<contentOptionDescription>` dans `$<channelOptionDescription>`\nTape `/$<commandName> $<patchSubCommandName> $<channelOptionDescription> $<messageOptionDescription>` $<contentOptionDescription> pour modifier `$<messageOptionDescription>` avec `$<contentOptionDescription>` dans `$<channelOptionDescription>`\nTape `/$<commandName> $<attachSubCommandName> $<channelOptionDescription> $<messageOptionDescription> $<positionOptionDescription> $<attachmentOptionDescription>` pour ajouter à `$<positionOptionDescription>` `$<attachmentOptionDescription>` à `$<messageOptionDescription>` dans `$<channelOptionDescription>`\nTape `/$<commandName> $<detachSubCommandName> $<channelOptionDescription> $<messageOptionDescription> $<positionOptionDescription>` pour retirer à `$<positionOptionDescription>` la pièce jointe de `$<messageOptionDescription>` dans `$<channelOptionDescription>`"
+	},
+	"reply": {
+		"en-US": "I have edited the message.",
+		"fr": "J'ai modifié le message."
+	},
+	"bareReply": {
+		"en-US": "I have sent the message.",
+		"fr": "J'ai envoyé le message."
+	},
+	"noPrivacyReply": {
+		"en-US": "I can not reply to you in this channel.\nPlease ask me in a private channel instead.",
+		"fr": "Je ne peux pas te répondre dans ce salon.\nMerci de me demander dans un salon privé à la place."
+	},
+	"noChannelReply": {
+		"en-US": "I do not know any channel with this tag.",
+		"fr": "Je ne connais aucun salon avec cette étiquette."
+	},
+	"noMessageReply": {
+		"en-US": "I do not know any message with this identifier in this channel.",
+		"fr": "Je ne connais aucun message avec cet identifiant dans ce salon."
+	},
+	"noPositionReply": {
+		"en-US": "I do not know any slot with this position.\nPlease give me a position between `0` and `$<max>` instead.",
+		"fr": "Je ne connais aucun emplacement avec cette position.\nMerci de me donner une position entre `0` et `$<max>` à la place."
+	},
+	"noInteractionReply": {
+		"en-US": "I can not edit interaction replies or follow-ups.",
+		"fr": "Je ne peux pas modifier de réponses ou de suites aux interactions."
+	},
+	"noContentOrAttachmentReply": {
+		"en-US": "Please keep a content or attachments.",
+		"fr": "Merci de garder un contenu ou des pièces jointes."
+	},
+	"noPatchPermissionReply": {
+		"en-US": "I do not have the rights to edit this message.",
+		"fr": "Je n'ai pas les droits pour modifier ce message."
+	},
+	"noPostPermissionReply": {
+		"en-US": "I do not have the rights to send this message.",
+		"fr": "Je n'ai pas les droits pour envoyer ce message."
+	}
+}

--- a/src/definitions/count.json
+++ b/src/definitions/count.json
@@ -1,0 +1,15 @@
+{
+	"commandName": "count",
+	"commandDescription": {
+		"en-US": "Tells you what is the number of members on the server",
+		"fr": "Te dit quel est le nombre de membres sur le serveur"
+	},
+	"help": {
+		"en-US": "Type `/$<commandName>` to know what is the number of members on the server",
+		"fr": "Tape `/$<commandName>` pour savoir quel est le nombre de membres sur le serveur"
+	},
+	"reply": {
+		"en-US": "There are $<memberCount> members on the official *$<name>* *Discord* server!",
+		"fr": "Il y a $<memberCount> membres sur le serveur *Discord* officiel de *$<name>* !"
+	}
+}

--- a/src/definitions/emoji.json
+++ b/src/definitions/emoji.json
@@ -1,0 +1,25 @@
+{
+	"commandName": "emoji",
+	"commandDescription": {
+		"en-US": "Creates a new emoji starting from this base and customized with these styles",
+		"fr": "Crée un nouvel émoji à partir de cette base et personnalisé avec ces styles"
+	},
+	"baseOptionName": "base",
+	"baseOptionDescription": {
+		"en-US": "Some base",
+		"fr": "Une base"
+	},
+	"stylesOptionName": "styles",
+	"stylesOptionDescription": {
+		"en-US": "Some styles",
+		"fr": "Des styles"
+	},
+	"help": {
+		"en-US": "Type `/$<commandName> $<baseOptionDescription> $<stylesOptionDescription>` to create a new `$<baseOptionDescription>`-based emoji customized with `$<stylesOptionDescription>`",
+		"fr": "Tape `/$<commandName> $<baseOptionDescription> $<stylesOptionDescription>` pour créer un nouvel émoji basé sur `$<baseOptionDescription>` personnalisé avec `$<stylesOptionDescription>`"
+	},
+	"noPrivacyReply": {
+		"en-US": "I can not reply to you in this channel.\nPlease ask me in a private channel instead.",
+		"fr": "Je ne peux pas te répondre dans ce salon.\nMerci de me demander dans un salon privé à la place."
+	}
+}

--- a/src/definitions/help.json
+++ b/src/definitions/help.json
@@ -1,0 +1,15 @@
+{
+	"commandName": "help",
+	"commandDescription": {
+		"en-US": "Tells you what are the features I offer",
+		"fr": "Te dit quelles sont les fonctionnalités que je propose"
+	},
+	"help": {
+		"en-US": "Type `/$<commandName>` to know what are the features I offer",
+		"fr": "Tape `/$<commandName>` pour savoir quelles sont les fonctionnalités que je propose"
+	},
+	"reply": {
+		"en-US": "Hey $<user>, there you are!\nI can give you some advice about the server:\n$<featureList>",
+		"fr": "Ah $<user>, tu es là !\nJe peux te donner des conseils sur le serveur :\n$<featureList>"
+	}
+}

--- a/src/definitions/leaderboard.json
+++ b/src/definitions/leaderboard.json
@@ -1,0 +1,19 @@
+{
+	"commandName": "leaderboard",
+	"commandDescription": {
+		"en-US": "Tells you where to watch community speedruns of the game",
+		"fr": "Te dit où regarder des speedruns communautaires du jeu"
+	},
+	"help": {
+		"en-US": "Type `/$<commandName>` to know where to watch community speedruns of the game",
+		"fr": "Tape `/$<commandName>` pour savoir où regarder des speedruns communautaires du jeu"
+	},
+	"reply": {
+		"en-US": "You can watch community speedruns there:\n$<linkList>",
+		"fr": "Tu peux regarder des speedruns communautaires là :\n$<linkList>"
+	},
+	"link": {
+		"en-US": "[*$<title>* leaderboard](<$<link>>)",
+		"fr": "[Classement *$<title>*](<$<link>>)"
+	}
+}

--- a/src/definitions/mission.json
+++ b/src/definitions/mission.json
@@ -1,0 +1,36 @@
+{
+	"commandName": "mission",
+	"commandDescription": {
+		"en-US": "Tells you what is playable in the shop or when it is playable",
+		"fr": "Te dit ce qui est jouable dans la boutique ou quand c'est jouable"
+	},
+	"missionOptionName": "mission",
+	"missionOptionDescription": {
+		"en-US": "Some mission",
+		"fr": "Une mission"
+	},
+	"help": {
+		"en-US": "Type `/$<commandName>` to know what is playable in the shop\nType `/$<commandName> $<missionOptionDescription>` to know when `$<missionOptionDescription>` is playable in the shop",
+		"fr": "Tape `/$<commandName>` pour savoir ce qui est jouable dans la boutique\nTape `/$<commandName> $<missionOptionDescription>` pour savoir quand `$<missionOptionDescription>` est jouable dans la boutique"
+	},
+	"reply": {
+		"en-US": "**$<challengeName>** in **$<levelName>** will be playable for 1 day starting:\n$<scheduleList>",
+		"fr": "**$<challengeName>** dans **$<levelName>** sera jouable durant 1 jour à partir de :\n$<scheduleList>"
+	},
+	"bareReply": {
+		"en-US": "Each mission starts at *$<dayTime>*:\n$<scheduleList>",
+		"fr": "Chaque mission commence à *$<dayTime>* :\n$<scheduleList>"
+	},
+	"missionName": {
+		"en-US": "$<challengeName> in $<levelName>",
+		"fr": "$<challengeName> dans $<levelName>"
+	},
+	"schedule": {
+		"en-US": "*$<dayDateTime>*",
+		"fr": "*$<dayDateTime>*"
+	},
+	"bareSchedule": {
+		"en-US": "*$<dayDate>*: **$<challengeName>** in **$<levelName>**",
+		"fr": "*$<dayDate>* : **$<challengeName>** dans **$<levelName>**"
+	}
+}

--- a/src/definitions/outfit.json
+++ b/src/definitions/outfit.json
@@ -1,0 +1,48 @@
+{
+	"commandName": "outfit",
+	"commandDescription": {
+		"en-US": "Tells you what is for sale in the shop or when it is for sale",
+		"fr": "Te dit ce qui est en vente dans la boutique ou quand c'est en vente"
+	},
+	"outfitOptionName": "outfit",
+	"outfitOptionDescription": {
+		"en-US": "Some outfit",
+		"fr": "Un costume"
+	},
+	"help": {
+		"en-US": "Type `/$<commandName>` to know what is for sale in the shop\nType `/$<commandName> $<outfitOptionDescription>` to know when `$<outfitOptionDescription>` is for sale in the shop",
+		"fr": "Tape `/$<commandName>` pour savoir ce qui est en vente dans la boutique\nTape `/$<commandName> $<outfitOptionDescription>` pour savoir quand `$<outfitOptionDescription>` est en vente dans la boutique"
+	},
+	"reply": {
+		"en-US": "**$<outfitName>** will be for sale in the shop for $<costConjunction> for 6 hours starting:\n$<scheduleList>",
+		"fr": "**$<outfitName>** sera en vente dans la boutique pour $<costConjunction> durant 6 heures à partir de :\n$<scheduleList>"
+	},
+	"bareReply": {
+		"en-US": "The outfits for sale in the shop change every 6 hours:\n$<scheduleList>",
+		"fr": "Les costumes en vente dans la boutique changent toutes les 6 heures :\n$<scheduleList>"
+	},
+	"noSlotReply": {
+		"en-US": "**$<outfitName>** is not for sale.",
+		"fr": "**$<outfitName>** n'est pas en vente."
+	},
+	"tokensCost": {
+		"en-US": "**$<tokens> Tristopio tokens**",
+		"fr": "**$<tokens> jetons Tristopio**"
+	},
+	"coinsCost": {
+		"en-US": "**$<coins> coins**",
+		"fr": "**$<coins> pièces**"
+	},
+	"noCost": {
+		"en-US": "a pittance",
+		"fr": "une bouchée de pain"
+	},
+	"schedule": {
+		"en-US": "*$<dayDateTime>*",
+		"fr": "*$<dayDateTime>*"
+	},
+	"bareSchedule": {
+		"en-US": "*$<dayDateTime>*: $<outfitNameConjunction>",
+		"fr": "*$<dayDateTime>* : $<outfitNameConjunction>"
+	}
+}

--- a/src/definitions/raw.json
+++ b/src/definitions/raw.json
@@ -1,0 +1,29 @@
+{
+	"commandName": "raw",
+	"commandDescription": {
+		"en-US": "Tells you what is the datum of this type with this identifier",
+		"fr": "Te dit quelle est la donnée de ce type avec cet identifiant"
+	},
+	"typeOptionName": "type",
+	"typeOptionDescription": {
+		"en-US": "Some type",
+		"fr": "Un type"
+	},
+	"identifierOptionName": "identifier",
+	"identifierOptionDescription": {
+		"en-US": "Some identifier",
+		"fr": "Un identifiant"
+	},
+	"help": {
+		"en-US": "Type `/$<commandName> $<typeOptionDescription> $<identifierOptionDescription>` to know what is the datum of `$<typeOptionDescription>` with `$<identifierOptionDescription>`",
+		"fr": "Tape `/$<commandName> $<typeOptionDescription> $<identifierOptionDescription>` pour savoir quel est la donnée d'`$<typeOptionDescription>` avec `$<identifierOptionDescription>`"
+	},
+	"noTypeReply": {
+		"en-US": "I do not know any datum with this name.\nPlease give me a type among $<typeConjunction> instead.",
+		"fr": "Je ne connais aucune donnée avec ce nom.\nMerci de me donner un type parmi $<typeConjunction> à la place."
+	},
+	"noIdentifierReply": {
+		"en-US": "I do not know any datum with this identifier.\nPlease give me an identifier between `0` and `$<max>` instead.",
+		"fr": "Je ne connais aucune donnée avec cet identifiant.\nMerci de me donner un identifiant entre `0` et `$<max>` à la place."
+	}
+}

--- a/src/definitions/record.json
+++ b/src/definitions/record.json
@@ -1,0 +1,6 @@
+{
+	"help": {
+		"en-US": "I post the latest world records of the game in $<channel>",
+		"fr": "Je poste les derniers records du monde du jeu dans $<channel>"
+	}
+}

--- a/src/definitions/roadmap.json
+++ b/src/definitions/roadmap.json
@@ -1,0 +1,23 @@
+{
+	"commandName": "roadmap",
+	"commandDescription": {
+		"en-US": "Tells you where to check the upcoming milestones of the game",
+		"fr": "Te dit où consulter les futurs jalons du jeu"
+	},
+	"help": {
+		"en-US": "Type `/$<commandName>` to know where to check the upcoming milestones of the game",
+		"fr": "Tape `/$<commandName>` pour savoir où consulter les futurs jalons du jeu"
+	},
+	"reply": {
+		"en-US": "$<intent> check upcoming milestones of the game [there](<$<link>>).",
+		"fr": "$<intent> consulter de futurs jalons du jeu [là](<$<link>>)."
+	},
+	"intentWithChannel": {
+		"en-US": "Before suggesting an idea in $<channel>, you can",
+		"fr": "Avant de suggérer une idée dans $<channel>, tu peux"
+	},
+	"intentWithoutChannel": {
+		"en-US": "You can",
+		"fr": "Tu peux"
+	}
+}

--- a/src/definitions/rule7.json
+++ b/src/definitions/rule7.json
@@ -1,0 +1,6 @@
+{
+	"help": {
+		"en-US": "I will gently reprimand you if you write words which violate the rule 7 in $<channel>",
+		"fr": "Je te réprimanderai gentiment si tu écris des mots qui violent la règle 7 dans $<channel>"
+	}
+}

--- a/src/definitions/soundtrack.json
+++ b/src/definitions/soundtrack.json
@@ -1,0 +1,23 @@
+{
+	"commandName": "soundtrack",
+	"commandDescription": {
+		"en-US": "Tells you where to listen to official music pieces of the game",
+		"fr": "Te dit où écouter des morceaux de musique officiels du jeu"
+	},
+	"help": {
+		"en-US": "Type `/$<commandName>` to know where to listen to official music pieces of the game",
+		"fr": "Tape `/$<commandName>` pour savoir où écouter des morceaux de musique officiels du jeu"
+	},
+	"reply": {
+		"en-US": "You can listen to official music pieces of the game there:\n$<linkList>",
+		"fr": "Tu peux écouter des morceaux de musique officiels du jeu là :\n$<linkList>"
+	},
+	"defaultReply": {
+		"en-US": "You can listen to official music pieces of the game [there](<$<link>>).",
+		"fr": "Tu peux écouter des morceaux de musique officiels du jeu [là](<$<link>>)."
+	},
+	"link": {
+		"en-US": "[*$<title>* soundtrack](<$<link>>) (*$<views>* views)",
+		"fr": "[Bande-son *$<title>*](<$<link>>) (*$<views>* vues)"
+	}
+}

--- a/src/definitions/store.json
+++ b/src/definitions/store.json
@@ -1,0 +1,19 @@
+{
+	"commandName": "store",
+	"commandDescription": {
+		"en-US": "Tells you where to buy offical products of the game",
+		"fr": "Te dit où acheter des produits officiels du jeu"
+	},
+	"help": {
+		"en-US": "Type `/$<commandName>` to know where to buy offical products of the game",
+		"fr": "Tape `/$<commandName>` pour savoir où acheter des produits officiels du jeu"
+	},
+	"reply": {
+		"en-US": "You can buy official products of the game there:\n$<linkList>",
+		"fr": "Tu peux acheter des produits officiels du jeu là :\n$<linkList>"
+	},
+	"link": {
+		"en-US": "[$<title> store](<$<link>>)",
+		"fr": "[Magasin $<title>](<$<link>>)"
+	}
+}

--- a/src/definitions/tracker.json
+++ b/src/definitions/tracker.json
@@ -1,0 +1,27 @@
+{
+	"commandName": "tracker",
+	"commandDescription": {
+		"en-US": "Tells you where to check known bugs of the game",
+		"fr": "Te dit où consulter des bogues connus du jeu"
+	},
+	"help": {
+		"en-US": "Type `/$<commandName>` to know where to check known bugs of the game",
+		"fr": "Tape `/$<commandName>` pour savoir où consulter des bogues connus du jeu"
+	},
+	"reply": {
+		"en-US": "$<intent> check the known bugs of the game there:\n$<linkList>",
+		"fr": "$<intent> consulter des bogues connus du jeu là :\n$<linkList>"
+	},
+	"intentWithChannel": {
+		"en-US": "Before reporting a bug in $<channel>, you can",
+		"fr": "Avant de rapporter un bogue dans $<channel>, tu peux"
+	},
+	"intentWithoutChannel": {
+		"en-US": "You can",
+		"fr": "Tu peux"
+	},
+	"link": {
+		"en-US": "[$<title> tracker](<$<link>>)",
+		"fr": "[Suivi $<title>](<$<link>>)"
+	}
+}

--- a/src/definitions/trailer.json
+++ b/src/definitions/trailer.json
@@ -1,0 +1,23 @@
+{
+	"commandName": "trailer",
+	"commandDescription": {
+		"en-US": "Tells you where to watch official trailers of the game",
+		"fr": "Te dit où regarder des bandes-annonces officielles du jeu"
+	},
+	"help": {
+		"en-US": "Type `/$<commandName>` to know where to watch official trailers of the game",
+		"fr": "Tape `/$<commandName>` pour savoir où regarder des bandes-annonces officielles du jeu"
+	},
+	"reply": {
+		"en-US": "You can watch official trailers of the game there:\n$<linkList>",
+		"fr": "Tu peux regarder des bandes-annonces officielles du jeu là :\n$<linkList>"
+	},
+	"defaultReply": {
+		"en-US": "You can watch official trailers of the game [there](<$<link>>).",
+		"fr": "Tu peux regarder des bandes-annonces officielles du jeu [là](<$<link>>)."
+	},
+	"link": {
+		"en-US": "[*$<title>* trailer](<$<link>>) (*$<views>* views)",
+		"fr": "[Bande-annonce *$<title>*](<$<link>>) (*$<views>* views)"
+	}
+}

--- a/src/definitions/trailer.json
+++ b/src/definitions/trailer.json
@@ -18,6 +18,6 @@
 	},
 	"link": {
 		"en-US": "[*$<title>* trailer](<$<link>>) (*$<views>* views)",
-		"fr": "[Bande-annonce *$<title>*](<$<link>>) (*$<views>* views)"
+		"fr": "[Bande-annonce *$<title>*](<$<link>>) (*$<views>* vues)"
 	}
 }

--- a/src/definitions/update.json
+++ b/src/definitions/update.json
@@ -1,0 +1,23 @@
+{
+	"commandName": "update",
+	"commandDescription": {
+		"en-US": "Tells you what is the latest update of the game",
+		"fr": "Te dit quelle est la dernière mise à jour du jeu"
+	},
+	"help": {
+		"en-US": "Type `/$<commandName>` to know what is the latest update of the game",
+		"fr": "Tape `/$<commandName>` pour savoir quelle est la dernière mise à jour du jeu"
+	},
+	"reply": {
+		"en-US": "You can check and download the latest update of the game there:\n$<linkList>",
+		"fr": "Tu peux consulter et télécharger la dernière mise à jour du jeu là :\n$<linkList>"
+	},
+	"defaultReply": {
+		"en-US": "You can check and download the latest update of the game there:\n$<linkList>",
+		"fr": "Tu peux consulter et télécharger la dernière mise à jour du jeu là :\n$<linkList>"
+	},
+	"link": {
+		"en-US": "[*$<title>* platform](<$<link>>) (*$<version>* version as of *$<date>*)",
+		"fr": "[Plateforme *$<title>*](<$<link>>) (version *$<version>* au *$<date>*)"
+	}
+}

--- a/src/dependencies.d.ts
+++ b/src/dependencies.d.ts
@@ -1,0 +1,58 @@
+import type AboutDependency from "./dependencies/about.js";
+import type BearDependency from "./dependencies/bear.js";
+import type ChatDependency from "./dependencies/chat.js";
+import type CountDependency from "./dependencies/count.js";
+import type EmojiDependency from "./dependencies/emoji.js";
+import type HelpDependency from "./dependencies/help.js";
+import type LeaderboardDependency from "./dependencies/leaderboard.js";
+import type MissionDependency from "./dependencies/mission.js";
+import type OutfitDependency from "./dependencies/outfit.js";
+import type RawDependency from "./dependencies/raw.js";
+import type RecordDependency from "./dependencies/record.js";
+import type RoadmapDependency from "./dependencies/roadmap.js";
+import type Rule7Dependency from "./dependencies/rule7.js";
+import type SoundtrackDependency from "./dependencies/soundtrack.js";
+import type StoreDependency from "./dependencies/store.js";
+import type TrackerDependency from "./dependencies/tracker.js";
+import type TrailerDependency from "./dependencies/trailer.js";
+import type UpdateDependency from "./dependencies/update.js";
+type About = AboutDependency;
+type Bear = BearDependency;
+type Chat = ChatDependency;
+type Count = CountDependency;
+type Emoji = EmojiDependency;
+type Help = HelpDependency;
+type Leaderboard = LeaderboardDependency;
+type Mission = MissionDependency;
+type Outfit = OutfitDependency;
+type Raw = RawDependency;
+type Record = RecordDependency;
+type Roadmap = RoadmapDependency;
+type Rule7 = Rule7Dependency;
+type Soundtrack = SoundtrackDependency;
+type Store = StoreDependency;
+type Tracker = TrackerDependency;
+type Trailer = TrailerDependency;
+type Update = UpdateDependency;
+type Dependency = About | Bear | Chat | Count | Emoji | Help | Leaderboard | Mission | Outfit | Raw | Record | Roadmap | Rule7 | Soundtrack | Store | Tracker | Trailer | Update;
+export default Dependency;
+export type {
+	About,
+	Bear,
+	Chat,
+	Count,
+	Emoji,
+	Help,
+	Leaderboard,
+	Mission,
+	Outfit,
+	Raw,
+	Record,
+	Roadmap,
+	Rule7,
+	Soundtrack,
+	Store,
+	Tracker,
+	Trailer,
+	Update,
+};

--- a/src/dependencies/about.d.ts
+++ b/src/dependencies/about.d.ts
@@ -1,0 +1,13 @@
+type HelpGroups = {
+	commandName: () => string,
+};
+type ReplyGroups = {
+	bot: () => string,
+	author: () => string,
+	link: () => string,
+};
+type AboutDependency = {
+	help: HelpGroups,
+	reply: ReplyGroups,
+};
+export default AboutDependency;

--- a/src/dependencies/bear.d.ts
+++ b/src/dependencies/bear.d.ts
@@ -1,0 +1,31 @@
+type HelpGroups = {
+	commandName: () => string,
+	bearOptionDescription: () => string,
+};
+type ReplyGroups = {
+	name: () => string,
+	level: () => string,
+	outfitNameConjunction: () => string,
+	goalConjunction: () => string,
+};
+type NoOutfitGroups = {};
+type BossGoalGroups = {
+	boss: () => string,
+};
+type CoinsGoalGroups = {
+	coins: () => string,
+};
+type TimeGoalGroups = {
+	time: () => string,
+};
+type NoGoalGroups = {};
+type BearDependency = {
+	help: HelpGroups,
+	reply: ReplyGroups,
+	noOutfit: NoOutfitGroups,
+	bossGoal: BossGoalGroups,
+	coinsGoal: CoinsGoalGroups,
+	timeGoal: TimeGoalGroups,
+	noGoal: NoGoalGroups,
+};
+export default BearDependency;

--- a/src/dependencies/chat.d.ts
+++ b/src/dependencies/chat.d.ts
@@ -1,0 +1,38 @@
+type HelpGroups = {
+	commandName: () => string,
+	postSubCommandName: () => string,
+	patchSubCommandName: () => string,
+	attachSubCommandName: () => string,
+	detachSubCommandName: () => string,
+	channelOptionDescription: () => string,
+	messageOptionDescription: () => string,
+	contentOptionDescription: () => string,
+	positionOptionDescription: () => string,
+	attachmentOptionDescription: () => string,
+};
+type ReplyGroups = {};
+type BareReplyGroups = {};
+type NoPrivacyReplyGroups = {};
+type NoChannelReplyGroups = {};
+type NoMessageReplyGroups = {};
+type NoPositionReplyGroups = {
+	max: () => string,
+};
+type NoContentOrAttachmentReplyGroups = {};
+type NoInteractionReplyGroups = {};
+type NoPatchPermissionReplyGroups = {};
+type NoPostPermissionReplyGroups = {};
+type ChatDependency = {
+	help: HelpGroups,
+	reply: ReplyGroups,
+	bareReply: BareReplyGroups,
+	noPrivacyReply: NoPrivacyReplyGroups,
+	noChannelReply: NoChannelReplyGroups,
+	noMessageReply: NoMessageReplyGroups,
+	noPositionReply: NoPositionReplyGroups,
+	noContentOrAttachmentReply: NoContentOrAttachmentReplyGroups,
+	noInteractionReply: NoInteractionReplyGroups,
+	noPatchPermissionReply: NoPatchPermissionReplyGroups,
+	noPostPermissionReply: NoPostPermissionReplyGroups,
+};
+export default ChatDependency;

--- a/src/dependencies/count.d.ts
+++ b/src/dependencies/count.d.ts
@@ -1,0 +1,12 @@
+type HelpGroups = {
+	commandName: () => string,
+};
+type ReplyGroups = {
+	memberCount: () => string,
+	name: () => string,
+};
+type CountDependency = {
+	help: HelpGroups,
+	reply: ReplyGroups,
+};
+export default CountDependency;

--- a/src/dependencies/emoji.d.ts
+++ b/src/dependencies/emoji.d.ts
@@ -1,0 +1,11 @@
+type HelpGroups = {
+	commandName: () => string,
+	baseOptionDescription: () => string,
+	stylesOptionDescription: () => string,
+};
+type NoPrivacyReplyGroups = {};
+type EmojiDependency = {
+	help: HelpGroups,
+	noPrivacyReply: NoPrivacyReplyGroups,
+};
+export default EmojiDependency;

--- a/src/dependencies/help.d.ts
+++ b/src/dependencies/help.d.ts
@@ -1,0 +1,12 @@
+type HelpGroups = {
+	commandName: () => string,
+};
+type ReplyGroups = {
+	user: () => string,
+	featureList: () => string,
+};
+type HelpDependency = {
+	help: HelpGroups,
+	reply: ReplyGroups,
+};
+export default HelpDependency;

--- a/src/dependencies/leaderboard.d.ts
+++ b/src/dependencies/leaderboard.d.ts
@@ -1,0 +1,16 @@
+type HelpGroups = {
+	commandName: () => string,
+};
+type ReplyGroups = {
+	linkList: () => string,
+};
+type LinkGroups = {
+	title: () => string,
+	link: () => string,
+};
+type LeaderboardDependency = {
+	help: HelpGroups,
+	reply: ReplyGroups,
+	link: LinkGroups,
+};
+export default LeaderboardDependency;

--- a/src/dependencies/mission.d.ts
+++ b/src/dependencies/mission.d.ts
@@ -1,0 +1,34 @@
+type HelpGroups = {
+	commandName: () => string,
+	missionOptionDescription: () => string,
+};
+type ReplyGroups = {
+	challengeName: () => string,
+	levelName: () => string,
+	scheduleList: () => string,
+};
+type BareReplyGroups = {
+	dayTime: () => string,
+	scheduleList: () => string,
+};
+type MissionNameGroups = {
+	challengeName: () => string,
+	levelName: () => string,
+};
+type ScheduleGroups = {
+	dayDateTime: () => string,
+};
+type BareScheduleGroups = {
+	dayDate: () => string,
+	challengeName: () => string,
+	levelName: () => string,
+};
+type MissionDependency = {
+	help: HelpGroups,
+	reply: ReplyGroups,
+	bareReply: BareReplyGroups,
+	missionName: MissionNameGroups,
+	schedule: ScheduleGroups,
+	bareSchedule: BareScheduleGroups,
+};
+export default MissionDependency;

--- a/src/dependencies/outfit.d.ts
+++ b/src/dependencies/outfit.d.ts
@@ -1,0 +1,41 @@
+type HelpGroups = {
+	commandName: () => string,
+	outfitOptionDescription: () => string,
+};
+type ReplyGroups = {
+	outfitName: () => string,
+	costConjunction: () => string,
+	scheduleList: () => string,
+};
+type BareReplyGroups = {
+	scheduleList: () => string,
+};
+type NoSlotReplyGroups = {
+	outfitName: () => string,
+};
+type TokensCostGroups = {
+	tokens: () => string,
+};
+type CoinsCostGroups = {
+	coins: () => string,
+};
+type NoCostGroups = {};
+type ScheduleGroups = {
+	dayDateTime: () => string,
+};
+type BareScheduleGroups = {
+	dayDateTime: () => string,
+	outfitNameConjunction: () => string,
+};
+type OutfitDependency = {
+	help: HelpGroups,
+	reply: ReplyGroups,
+	bareReply: BareReplyGroups,
+	noSlotReply: NoSlotReplyGroups,
+	tokensCost: TokensCostGroups,
+	coinsCost: CoinsCostGroups,
+	noCost: NoCostGroups,
+	schedule: ScheduleGroups,
+	bareSchedule: BareScheduleGroups,
+};
+export default OutfitDependency;

--- a/src/dependencies/raw.d.ts
+++ b/src/dependencies/raw.d.ts
@@ -1,0 +1,17 @@
+type HelpGroups = {
+	commandName: () => string,
+	typeOptionDescription: () => string,
+	identifierOptionDescription: () => string,
+};
+type NoTypeReplyGroups = {
+	typeConjunction: () => string,
+};
+type NoIdentifierReplyGroups = {
+	max: () => string,
+};
+type RawDependency = {
+	help: HelpGroups,
+	noTypeReply: NoTypeReplyGroups,
+	noIdentifierReply: NoIdentifierReplyGroups,
+};
+export default RawDependency;

--- a/src/dependencies/record.d.ts
+++ b/src/dependencies/record.d.ts
@@ -1,0 +1,7 @@
+type HelpGroups = {
+	channel: () => string,
+};
+type HelpDependency = {
+	help: HelpGroups,
+};
+export default HelpDependency;

--- a/src/dependencies/roadmap.d.ts
+++ b/src/dependencies/roadmap.d.ts
@@ -1,0 +1,18 @@
+type HelpGroups = {
+	commandName: () => string,
+};
+type ReplyGroups = {
+	intent: () => string,
+	link: () => string,
+};
+type IntentWithChannelGroups = {
+	channel: () => string,
+};
+type IntentWithoutChannelGroups = {};
+type RoadmapDependency = {
+	help: HelpGroups,
+	reply: ReplyGroups,
+	intentWithChannel: IntentWithChannelGroups,
+	intentWithoutChannel: IntentWithoutChannelGroups,
+};
+export default RoadmapDependency;

--- a/src/dependencies/rule7.d.ts
+++ b/src/dependencies/rule7.d.ts
@@ -1,0 +1,7 @@
+type HelpGroups = {
+	channel: () => string,
+};
+type Rule7Dependency = {
+	help: HelpGroups,
+};
+export default Rule7Dependency;

--- a/src/dependencies/soundtrack.d.ts
+++ b/src/dependencies/soundtrack.d.ts
@@ -1,0 +1,21 @@
+type HelpGroups = {
+	commandName: () => string,
+};
+type ReplyGroups = {
+	linkList: () => string,
+};
+type DefaultReplyGroups = {
+	link: () => string,
+};
+type LinkGroups = {
+	title: () => string,
+	link: () => string,
+	views: () => string,
+};
+type SoundtrackDependency = {
+	help: HelpGroups,
+	reply: ReplyGroups,
+	defaultReply: DefaultReplyGroups,
+	link: LinkGroups,
+};
+export default SoundtrackDependency;

--- a/src/dependencies/store.d.ts
+++ b/src/dependencies/store.d.ts
@@ -1,0 +1,16 @@
+type HelpGroups = {
+	commandName: () => string,
+};
+type ReplyGroups = {
+	linkList: () => string,
+};
+type LinkGroups = {
+	title: () => string,
+	link: () => string,
+};
+type StoreDependency = {
+	help: HelpGroups,
+	reply: ReplyGroups,
+	link: LinkGroups,
+};
+export default StoreDependency;

--- a/src/dependencies/tracker.d.ts
+++ b/src/dependencies/tracker.d.ts
@@ -1,0 +1,23 @@
+type HelpGroups = {
+	commandName: () => string,
+};
+type ReplyGroups = {
+	intent: () => string,
+	linkList: () => string,
+};
+type IntentWithChannelGroups = {
+	channel: () => string,
+};
+type IntentWithoutChannelGroups = {};
+type LinkGroups = {
+	title: () => string,
+	link: () => string,
+};
+type TrackerDependency = {
+	help: HelpGroups,
+	reply: ReplyGroups,
+	intentWithChannel: IntentWithChannelGroups,
+	intentWithoutChannel: IntentWithoutChannelGroups,
+	link: LinkGroups,
+};
+export default TrackerDependency;

--- a/src/dependencies/trailer.d.ts
+++ b/src/dependencies/trailer.d.ts
@@ -1,0 +1,21 @@
+type HelpGroups = {
+	commandName: () => string,
+};
+type ReplyGroups = {
+	linkList: () => string,
+};
+type DefaultReplyGroups = {
+	link: () => string,
+};
+type LinkGroups = {
+	title: () => string,
+	link: () => string,
+	views: () => string,
+};
+type TrailerDependency = {
+	help: HelpGroups,
+	reply: ReplyGroups,
+	defaultReply: DefaultReplyGroups,
+	link: LinkGroups,
+};
+export default TrailerDependency;

--- a/src/dependencies/update.d.ts
+++ b/src/dependencies/update.d.ts
@@ -1,0 +1,22 @@
+type HelpGroups = {
+	commandName: () => string,
+};
+type ReplyGroups = {
+	linkList: () => string,
+};
+type DefaultReplyGroups = {
+	linkList: () => string,
+};
+type LinkGroups = {
+	title: () => string,
+	link: () => string,
+	version: () => string,
+	date: () => string,
+};
+type UpdateDependency = {
+	help: HelpGroups,
+	reply: ReplyGroups,
+	defaultReply: DefaultReplyGroups,
+	link: LinkGroups,
+};
+export default UpdateDependency;

--- a/src/feeds/record.ts
+++ b/src/feeds/record.ts
@@ -6,15 +6,16 @@ import type {
 } from "discord.js";
 import type {Response} from "node-fetch";
 import type {Job} from "node-schedule";
+import type {Record as RecordCompilation} from "../compilations.js";
+import type {Record as RecordDependency} from "../dependencies.js";
 import type Feed from "../feeds.js";
 import type {Localized} from "../utils/string.js";
 import {Util} from "discord.js";
 import fetch from "node-fetch";
 import schedule from "node-schedule";
-import {compileAll, composeAll, localize} from "../utils/string.js";
-type HelpGroups = {
-	channel: () => string,
-};
+import {record as recordCompilation} from "../compilations.js";
+import {composeAll, localize} from "../utils/string.js";
+type HelpGroups = RecordDependency["help"];
 type Leaderboard = {
 	leaderboardName: string,
 };
@@ -26,14 +27,13 @@ type Level = {
 	levelName: string,
 	categories: {[k in string]: Category},
 };
+const {
+	help: helpLocalizations,
+}: RecordCompilation = recordCompilation;
 const games: string[] = ["9d3rrxyd", "w6jl2ned"];
 const conjunctionFormat: Intl.ListFormat = new Intl.ListFormat("en-US", {
 	style: "long",
 	type: "conjunction",
-});
-const helpLocalizations: Localized<(groups: HelpGroups) => string> = compileAll<HelpGroups>({
-	"en-US": "I post the latest world records of the game in $<channel>",
-	"fr": "Je poste les derniers records du monde du jeu dans $<channel>",
 });
 const recordFeed: Feed = {
 	register(client: Client): Job {

--- a/src/triggers/rule7.ts
+++ b/src/triggers/rule7.ts
@@ -6,18 +6,18 @@ import type {
 	Role,
 	ThreadChannel,
 } from "discord.js";
+import type {Rule7 as Rule7Compilation} from "../compilations.js";
+import type {Rule7 as Rule7Dependency} from "../dependencies.js";
 import type Trigger from "../triggers.js";
 import type {Localized} from "../utils/string.js";
-import {compileAll, composeAll, localize} from "../utils/string.js";
-type HelpGroups = {
-	channel: () => string,
-};
+import {rule7 as rule7Compilation} from "../compilations.js";
+import {composeAll, localize} from "../utils/string.js";
+type HelpGroups = Rule7Dependency["help"];
+const {
+	help: helpLocalizations,
+}: Rule7Compilation = rule7Compilation;
 const pattern: RegExp = /\b(?:co-?op(?:erati(?:ons?|ve))?|consoles?|multi(?:-?player)?|online|pc|playstation|ps[45]|switch|xbox)\b/iu;
 const roles: Set<string> = new Set<string>(["Administrator", "Game Developer", "Helper", "Moderator", "Cookie"]);
-const helpLocalizations: Localized<(groups: HelpGroups) => string> = compileAll<HelpGroups>({
-	"en-US": "I will gently reprimand you if you write words which violate the rule 7 in $<channel>",
-	"fr": "Je te réprimanderai gentiment si tu écris des mots qui violent la règle 7 dans $<channel>",
-});
 const rule7Trigger: Trigger = {
 	async execute(message: Message): Promise<void> {
 		const {guild}: Message = message;


### PR DESCRIPTION
This refactors the codebase to extract string definitions (command names and descriptions, option names and descriptions, help messages, reply messages and message fragments) to JSON files.
For this purpose, this also adds a lot of boilerplate code to declare types for these definitions.
That's the downside of making things declarative while having strict types...