### PR TITLE
Changes how the date of the latest Android update is retrieved

### DIFF
--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -67,7 +67,7 @@ const updateCommand: Command = {
 							title: "Android",
 							link: "https://play.google.com/store/apps/details?id=com.Earthkwak.Platformer",
 							version: result[1][2][140][0][0][0],
-							date: new Date(result[1][2][145][0][1][0] * 1000),
+							date: new Date(result[1][2][140][2][0]),
 						};
 					} catch {}
 				}


### PR DESCRIPTION
This retrieves the date as a string (which looks like being a `HTTP-date` from RFC 7231) instead of a timestamp, because apparently they do not update at the same moment.
The timestamp seems to be updated as soon as a game update starts to roll out, whereas the string seems to be updated later, only once it is fully released, just like the version number.
Using the `/update` command during this time window could give mismatching results, displaying the the old version number, but with the new date.
Parsing the string instead of using the timestamp fixes that.
Unfortunately, support for this kind of string format is implementation-defined, so there is no guarantee that it will work consistently.