### PR TITLE
Fixes links to leaderboards

### DIFF
--- a/src/commands/leaderboard.ts
+++ b/src/commands/leaderboard.ts
@@ -37,31 +37,31 @@ const data: Data[] = [
 	},
 	{
 		title: "Turtletown",
-		link: "https://www.speedrun.com/sba/Turtletown",
+		link: "https://www.speedrun.com/sba?x=l_r9gn1qpd",
 	},
 	{
 		title: "Snow Valley",
-		link: "https://www.speedrun.com/sba/Snow_Valley",
+		link: "https://www.speedrun.com/sba?x=l_o9xo3rp9",
 	},
 	{
 		title: "Beemothep Desert",
-		link: "https://www.speedrun.com/sba/Beemothep_Desert",
+		link: "https://www.speedrun.com/sba?x=l_495zlx39",
 	},
 	{
 		title: "Giant House",
-		link: "https://www.speedrun.com/sba/Giant_House",
+		link: "https://www.speedrun.com/sba?x=l_rdqo542w",
 	},
 	{
 		title: "The Hive",
-		link: "https://www.speedrun.com/sbace/The_Hive",
+		link: "https://www.speedrun.com/sbace?x=l_gdr5onk9",
 	},
 	{
 		title: "Missions",
-		link: "https://www.speedrun.com/sbace/Missions",
+		link: "https://www.speedrun.com/sbace?x=l_r9gnozkd",
 	},
 	{
 		title: "Races",
-		link: "https://www.speedrun.com/sbace/Races",
+		link: "https://www.speedrun.com/sbace?x=l_ldykv1zw",
 	},
 	{
 		title: "Full-game Category Extensions",


### PR DESCRIPTION
The redirects from the old URLs were broken in the last update of the site, even if they are still returned by the API.
Let's use the new links.