### PR TITLE
Adds verification commands

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -85,7 +85,11 @@ $ npm start
 
 - `trailer` gives the links to the trailers of the game on `www.youtube.com`
 
+- `unverification` refuses the author of the given message
+
 - `update` gives the links to the latest updates of the game on `play.google.com` and `apps.apple.com`
+
+- `verification` approves the author of the given message
 
 ### Hooks
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,8 +1,10 @@
 import type {
 	ApplicationCommand,
-	ApplicationCommandData,
 	AutocompleteInteraction,
+	ChatInputApplicationCommandData,
 	ChatInputCommandInteraction,
+	MessageApplicationCommandData,
+	MessageContextMenuCommandInteraction,
 } from "discord.js";
 import type {Localized} from "./utils/string.js";
 import aboutCommand from "./commands/about.js";
@@ -21,7 +23,8 @@ import storeCommand from "./commands/store.js";
 import trackerCommand from "./commands/tracker.js";
 import trailerCommand from "./commands/trailer.js";
 import updateCommand from "./commands/update.js";
-type ApplicationUserInteraction = AutocompleteInteraction<"cached"> | ChatInputCommandInteraction<"cached">;
+type ApplicationCommandData = ChatInputApplicationCommandData | MessageApplicationCommandData;
+type ApplicationUserInteraction = AutocompleteInteraction<"cached"> | ChatInputCommandInteraction<"cached"> | MessageContextMenuCommandInteraction<"cached">;
 type Command = {
 	register(): ApplicationCommandData;
 	interact(interaction: ApplicationUserInteraction): Promise<void>;

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -22,7 +22,9 @@ import soundtrackCommand from "./commands/soundtrack.js";
 import storeCommand from "./commands/store.js";
 import trackerCommand from "./commands/tracker.js";
 import trailerCommand from "./commands/trailer.js";
+import unverificationCommand from "./commands/unverification.js";
 import updateCommand from "./commands/update.js";
+import verificationCommand from "./commands/verification.js";
 type ApplicationCommandData = ChatInputApplicationCommandData | MessageApplicationCommandData;
 type ApplicationUserInteraction = AutocompleteInteraction<"cached"> | ChatInputCommandInteraction<"cached"> | MessageContextMenuCommandInteraction<"cached">;
 type Command = {
@@ -45,7 +47,9 @@ const soundtrack: Command = soundtrackCommand;
 const store: Command = storeCommand;
 const tracker: Command = trackerCommand;
 const trailer: Command = trailerCommand;
+const unverification: Command = unverificationCommand;
 const update: Command = updateCommand;
+const verification: Command = verificationCommand;
 export type {Command as default};
 export type {
 	ApplicationCommand,
@@ -68,5 +72,7 @@ export {
 	store,
 	tracker,
 	trailer,
+	unverification,
 	update,
+	verification,
 };

--- a/src/commands/chat.ts
+++ b/src/commands/chat.ts
@@ -496,7 +496,6 @@ const chatCommand: Command = {
 			});
 			return;
 		}
-		return;
 	},
 	describe(applicationCommand: ApplicationCommand): Localized<(groups: {}) => string> {
 		return composeAll<HelpGroups, {}>(helpLocalizations, localize<HelpGroups>((locale: Locale): HelpGroups => {

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -242,7 +242,7 @@ const helpCommand: Command = {
 				if (applicationCommand.guild == null) {
 					return null;
 				}
-				if (applicationCommand.type !== ApplicationCommandType.ChatInput) {
+				if (applicationCommand.type !== ApplicationCommandType.ChatInput && applicationCommand.type !== ApplicationCommandType.Message) {
 					return null;
 				}
 				if (applicationCommand.applicationId !== user.id) {

--- a/src/commands/unverification.ts
+++ b/src/commands/unverification.ts
@@ -1,0 +1,120 @@
+import type {
+	Guild,
+	Message,
+	MessageReaction,
+	Role,
+	MessageContextMenuCommandInteraction,
+	GuildMember,
+} from "discord.js";
+import type Command from "../commands.js";
+import type {ApplicationCommand, ApplicationCommandData, ApplicationUserInteraction} from "../commands.js";
+import type {Unverification as UnverificationCompilation} from "../compilations.js";
+import type {Unverification as UnverificationDefinition} from "../definitions.js";
+import type {Unverification as UnverificationDependency} from "../dependencies.js";
+import type {Locale, Localized} from "../utils/string.js";
+import {
+	ApplicationCommandType,
+} from "discord.js";
+import {unverification as unverificationCompilation} from "../compilations.js";
+import {unverification as unverificationDefinition} from "../definitions.js";
+import {composeAll, localize, resolve} from "../utils/string.js";
+type HelpGroups = UnverificationDependency["help"];
+const {
+	commandName,
+	commandDescription,
+}: UnverificationDefinition = unverificationDefinition;
+const {
+	help: helpLocalizations,
+	reply: replyLocalizations,
+	noMemberReply: noMemberReplyLocalizations,
+	noPermissionReply: noPermissionReplyLocalizations,
+}: UnverificationCompilation = unverificationCompilation;
+const {
+	SHICKA_APPROVAL_VERIFICATION_ROLE,
+	SHICKA_REFUSAL_UNVERIFICATION_ROLE,
+}: NodeJS.ProcessEnv = process.env;
+const commandUnverificationRole: string = SHICKA_REFUSAL_UNVERIFICATION_ROLE ?? "";
+const commandVerificationRole: string = SHICKA_APPROVAL_VERIFICATION_ROLE ?? "";
+const unverificationCommand: Command = {
+	register(): ApplicationCommandData {
+		return {
+			type: ApplicationCommandType.Message,
+			name: commandName,
+			nameLocalizations: commandDescription,
+			defaultMemberPermissions: [],
+			dmPermission: false,
+		};
+	},
+	async interact(interaction: ApplicationUserInteraction): Promise<void> {
+		if (!interaction.isMessageContextMenuCommand()) {
+			return;
+		}
+		const {guild, locale, targetMessage}: MessageContextMenuCommandInteraction<"cached"> = interaction;
+		const resolvedLocale: Locale = resolve(locale);
+		const {roles}: Guild = guild;
+		const unverificationRole: Role | undefined = roles.cache.find((role: Role): boolean => {
+			return role.name === commandUnverificationRole;
+		});
+		if (unverificationRole == null) {
+			return;
+		}
+		const verificationRole: Role | undefined = roles.cache.find((role: Role): boolean => {
+			return role.name === commandVerificationRole;
+		});
+		if (verificationRole == null) {
+			return;
+		}
+		const member: GuildMember | undefined = await (async (): Promise<GuildMember | undefined> => {
+			try {
+				const {author, member}: Message<true> = targetMessage;
+				if (member == null) {
+					const memberId: string = author.id;
+					const member: GuildMember | undefined = guild.members.cache.get(memberId);
+					if (member == null) {
+						return await guild.members.fetch(memberId);
+					}
+					return member;
+				}
+				return member;
+			} catch {}
+		})();
+		if (member == null) {
+			await interaction.reply({
+				content: noMemberReplyLocalizations[resolvedLocale]({}),
+				ephemeral: true,
+			});
+			return;
+		}
+		try {
+			await member.roles.remove(verificationRole);
+			await member.roles.remove(unverificationRole);
+		} catch {
+			await interaction.reply({
+				content: noPermissionReplyLocalizations[resolvedLocale]({}),
+				ephemeral: true,
+			});
+			return;
+		}
+		await targetMessage.react("❎");
+		const reaction: MessageReaction | undefined = targetMessage.reactions.cache.find((reaction: MessageReaction): boolean => {
+			return (reaction.emoji.name ?? "") === "✅";
+		});
+		if (reaction != null) {
+			await reaction.users.remove();
+		}
+		await interaction.reply({
+			content: replyLocalizations[resolvedLocale]({}),
+			ephemeral: true,
+		});
+	},
+	describe(applicationCommand: ApplicationCommand): Localized<(groups: {}) => string> {
+		return composeAll<HelpGroups, {}>(helpLocalizations, localize<HelpGroups>((locale: Locale): HelpGroups => {
+			return {
+				commandMention: (): string => {
+					return commandDescription[locale];
+				},
+			};
+		}));
+	},
+};
+export default unverificationCommand;

--- a/src/commands/verification.ts
+++ b/src/commands/verification.ts
@@ -1,0 +1,120 @@
+import type {
+	Guild,
+	Message,
+	MessageReaction,
+	Role,
+	MessageContextMenuCommandInteraction,
+	GuildMember,
+} from "discord.js";
+import type Command from "../commands.js";
+import type {ApplicationCommand, ApplicationCommandData, ApplicationUserInteraction} from "../commands.js";
+import type {Verification as VerificationCompilation} from "../compilations.js";
+import type {Verification as VerificationDefinition} from "../definitions.js";
+import type {Verification as VerificationDependency} from "../dependencies.js";
+import type {Locale, Localized} from "../utils/string.js";
+import {
+	ApplicationCommandType,
+} from "discord.js";
+import {verification as verificationCompilation} from "../compilations.js";
+import {verification as verificationDefinition} from "../definitions.js";
+import {composeAll, localize, resolve} from "../utils/string.js";
+type HelpGroups = VerificationDependency["help"];
+const {
+	commandName,
+	commandDescription,
+}: VerificationDefinition = verificationDefinition;
+const {
+	help: helpLocalizations,
+	reply: replyLocalizations,
+	noMemberReply: noMemberReplyLocalizations,
+	noPermissionReply: noPermissionReplyLocalizations,
+}: VerificationCompilation = verificationCompilation;
+const {
+	SHICKA_APPROVAL_VERIFICATION_ROLE,
+	SHICKA_REFUSAL_UNVERIFICATION_ROLE,
+}: NodeJS.ProcessEnv = process.env;
+const commandUnverificationRole: string = SHICKA_REFUSAL_UNVERIFICATION_ROLE ?? "";
+const commandVerificationRole: string = SHICKA_APPROVAL_VERIFICATION_ROLE ?? "";
+const verificationCommand: Command = {
+	register(): ApplicationCommandData {
+		return {
+			type: ApplicationCommandType.Message,
+			name: commandName,
+			nameLocalizations: commandDescription,
+			defaultMemberPermissions: [],
+			dmPermission: false,
+		};
+	},
+	async interact(interaction: ApplicationUserInteraction): Promise<void> {
+		if (!interaction.isMessageContextMenuCommand()) {
+			return;
+		}
+		const {guild, locale, targetMessage}: MessageContextMenuCommandInteraction<"cached"> = interaction;
+		const resolvedLocale: Locale = resolve(locale);
+		const {roles}: Guild = guild;
+		const unverificationRole: Role | undefined = roles.cache.find((role: Role): boolean => {
+			return role.name === commandUnverificationRole;
+		});
+		if (unverificationRole == null) {
+			return;
+		}
+		const verificationRole: Role | undefined = roles.cache.find((role: Role): boolean => {
+			return role.name === commandVerificationRole;
+		});
+		if (verificationRole == null) {
+			return;
+		}
+		const member: GuildMember | undefined = await (async (): Promise<GuildMember | undefined> => {
+			try {
+				const {author, member}: Message<true> = targetMessage;
+				if (member == null) {
+					const memberId: string = author.id;
+					const member: GuildMember | undefined = guild.members.cache.get(memberId);
+					if (member == null) {
+						return await guild.members.fetch(memberId);
+					}
+					return member;
+				}
+				return member;
+			} catch {}
+		})();
+		if (member == null) {
+			await interaction.reply({
+				content: noMemberReplyLocalizations[resolvedLocale]({}),
+				ephemeral: true,
+			});
+			return;
+		}
+		try {
+			await member.roles.add(verificationRole);
+			await member.roles.remove(unverificationRole);
+		} catch {
+			await interaction.reply({
+				content: noPermissionReplyLocalizations[resolvedLocale]({}),
+				ephemeral: true,
+			});
+			return;
+		}
+		await targetMessage.react("✅");
+		const reaction: MessageReaction | undefined = targetMessage.reactions.cache.find((reaction: MessageReaction): boolean => {
+			return (reaction.emoji.name ?? "") === "❎";
+		});
+		if (reaction != null) {
+			await reaction.users.remove();
+		}
+		await interaction.reply({
+			content: replyLocalizations[resolvedLocale]({}),
+			ephemeral: true,
+		});
+	},
+	describe(applicationCommand: ApplicationCommand): Localized<(groups: {}) => string> {
+		return composeAll<HelpGroups, {}>(helpLocalizations, localize<HelpGroups>((locale: Locale): HelpGroups => {
+			return {
+				commandMention: (): string => {
+					return commandDescription[locale];
+				},
+			};
+		}));
+	},
+};
+export default verificationCommand;

--- a/src/compilations.ts
+++ b/src/compilations.ts
@@ -19,7 +19,9 @@ import soundtrackCompilation from "./compilations/soundtrack.js";
 import storeCompilation from "./compilations/store.js";
 import trackerCompilation from "./compilations/tracker.js";
 import trailerCompilation from "./compilations/trailer.js";
+import unverificationCompilation from "./compilations/unverification.js";
 import updateCompilation from "./compilations/update.js";
+import verificationCompilation from "./compilations/verification.js";
 type About = typeof aboutCompilation;
 type Approval = typeof approvalCompilation;
 type Arrival = typeof arrivalCompilation;
@@ -41,8 +43,10 @@ type Soundtrack = typeof soundtrackCompilation;
 type Store = typeof storeCompilation;
 type Tracker = typeof trackerCompilation;
 type Trailer = typeof trailerCompilation;
+type Unverification = typeof unverificationCompilation;
 type Update = typeof updateCompilation;
-type Compilation = About | Approval | Arrival | Bear | Chat | Count | Departure | Emoji | Help | Leaderboard | Mission | Outfit | Raw | Record | Refusal | Roadmap | Rule7 | Soundtrack | Store | Tracker | Trailer | Update;
+type Verification = typeof verificationCompilation;
+type Compilation = About | Approval | Arrival | Bear | Chat | Count | Departure | Emoji | Help | Leaderboard | Mission | Outfit | Raw | Record | Refusal | Roadmap | Rule7 | Soundtrack | Store | Tracker | Trailer | Unverification | Update | Verification;
 const about: About = aboutCompilation;
 const approval: Approval = approvalCompilation;
 const arrival: Arrival = arrivalCompilation;
@@ -64,7 +68,9 @@ const soundtrack: Soundtrack = soundtrackCompilation;
 const store: Store = storeCompilation;
 const tracker: Tracker = trackerCompilation;
 const trailer: Trailer = trailerCompilation;
+const unverification: Unverification = unverificationCompilation;
 const update: Update = updateCompilation;
+const verification: Verification = verificationCompilation;
 export type {Compilation as default};
 export type {
 	About,
@@ -88,7 +94,9 @@ export type {
 	Store,
 	Tracker,
 	Trailer,
+	Unverification,
 	Update,
+	Verification,
 };
 export {
 	about,
@@ -112,5 +120,7 @@ export {
 	store,
 	tracker,
 	trailer,
+	unverification,
 	update,
+	verification,
 };

--- a/src/compilations/unverification.ts
+++ b/src/compilations/unverification.ts
@@ -1,0 +1,25 @@
+import type {Unverification} from "../dependencies.js";
+import type {Localized} from "../utils/string.js";
+import {unverification} from "../definitions.js";
+import {compileAll} from "../utils/string.js";
+type HelpLocalizations = Localized<(groups: Unverification["help"]) => string>;
+type ReplyLocalizations = Localized<(groups: Unverification["reply"]) => string>;
+type NoMemberReplyLocalizations = Localized<(groups: Unverification["noMemberReply"]) => string>;
+type NoPermissionReplyLocalizations = Localized<(groups: Unverification["noPermissionReply"]) => string>;
+type UnverificationCompilation = {
+	help: HelpLocalizations,
+	reply: ReplyLocalizations,
+	noMemberReply: NoMemberReplyLocalizations,
+	noPermissionReply: NoPermissionReplyLocalizations,
+};
+const helpLocalizations: HelpLocalizations = compileAll<Unverification["help"]>(unverification["help"]);
+const replyLocalizations: ReplyLocalizations = compileAll<Unverification["reply"]>(unverification["reply"]);
+const noMemberReplyLocalizations: NoMemberReplyLocalizations = compileAll<Unverification["noMemberReply"]>(unverification["noMemberReply"]);
+const noPermissionReplyLocalizations: NoPermissionReplyLocalizations = compileAll<Unverification["noPermissionReply"]>(unverification["noPermissionReply"]);
+const unverificationCompilation: UnverificationCompilation = {
+	help: helpLocalizations,
+	reply: replyLocalizations,
+	noMemberReply: noMemberReplyLocalizations,
+	noPermissionReply: noPermissionReplyLocalizations,
+};
+export default unverificationCompilation;

--- a/src/compilations/verification.ts
+++ b/src/compilations/verification.ts
@@ -1,0 +1,25 @@
+import type {Verification} from "../dependencies.js";
+import type {Localized} from "../utils/string.js";
+import {verification} from "../definitions.js";
+import {compileAll} from "../utils/string.js";
+type HelpLocalizations = Localized<(groups: Verification["help"]) => string>;
+type ReplyLocalizations = Localized<(groups: Verification["reply"]) => string>;
+type NoMemberReplyLocalizations = Localized<(groups: Verification["noMemberReply"]) => string>;
+type NoPermissionReplyLocalizations = Localized<(groups: Verification["noPermissionReply"]) => string>;
+type VerificationCompilation = {
+	help: HelpLocalizations,
+	reply: ReplyLocalizations,
+	noMemberReply: NoMemberReplyLocalizations,
+	noPermissionReply: NoPermissionReplyLocalizations,
+};
+const helpLocalizations: HelpLocalizations = compileAll<Verification["help"]>(verification["help"]);
+const replyLocalizations: ReplyLocalizations = compileAll<Verification["reply"]>(verification["reply"]);
+const noMemberReplyLocalizations: NoMemberReplyLocalizations = compileAll<Verification["noMemberReply"]>(verification["noMemberReply"]);
+const noPermissionReplyLocalizations: NoPermissionReplyLocalizations = compileAll<Verification["noPermissionReply"]>(verification["noPermissionReply"]);
+const verificationCompilation: VerificationCompilation = {
+	help: helpLocalizations,
+	reply: replyLocalizations,
+	noMemberReply: noMemberReplyLocalizations,
+	noPermissionReply: noPermissionReplyLocalizations,
+};
+export default verificationCompilation;

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -20,7 +20,9 @@ import soundtrackDefinition from "./definitions/soundtrack.json" assert {type: "
 import storeDefinition from "./definitions/store.json" assert {type: "json"};
 import trackerDefinition from "./definitions/tracker.json" assert {type: "json"};
 import trailerDefinition from "./definitions/trailer.json" assert {type: "json"};
+import unverificationDefinition from "./definitions/unverification.json" assert {type: "json"};
 import updateDefinition from "./definitions/update.json" assert {type: "json"};
+import verificationDefinition from "./definitions/verification.json" assert {type: "json"};
 type About = {
 	commandName: string,
 	commandDescription: Localized<string>,
@@ -218,6 +220,14 @@ type Trailer = {
 	defaultReply: Localized<string>,
 	link: Localized<string>,
 };
+type Unverification = {
+	commandName: string,
+	commandDescription: Localized<string>,
+	help: Localized<string>,
+	reply: Localized<string>,
+	noMemberReply: Localized<string>,
+	noPermissionReply: Localized<string>,
+};
 type Update = {
 	commandName: string,
 	commandDescription: Localized<string>,
@@ -226,7 +236,15 @@ type Update = {
 	defaultReply: Localized<string>,
 	link: Localized<string>,
 };
-type Definition = About | Approval | Arrival | Bear | Chat | Count | Departure | Emoji | Help | Leaderboard | Mission | Outfit | Raw | Record | Refusal | Roadmap | Rule7 | Soundtrack | Store | Tracker | Trailer | Update;
+type Verification = {
+	commandName: string,
+	commandDescription: Localized<string>,
+	help: Localized<string>,
+	reply: Localized<string>,
+	noMemberReply: Localized<string>,
+	noPermissionReply: Localized<string>,
+};
+type Definition = About | Approval | Arrival | Bear | Chat | Count | Departure | Emoji | Help | Leaderboard | Mission | Outfit | Raw | Record | Refusal | Roadmap | Rule7 | Soundtrack | Store | Tracker | Trailer | Unverification | Update | Verification;
 const about: About = aboutDefinition;
 const approval: Approval = approvalDefinition;
 const arrival: Arrival = arrivalDefinition;
@@ -248,7 +266,9 @@ const soundtrack: Soundtrack = soundtrackDefinition;
 const store: Store = storeDefinition;
 const tracker: Tracker = trackerDefinition;
 const trailer: Trailer = trailerDefinition;
+const unverification: Unverification = unverificationDefinition;
 const update: Update = updateDefinition;
+const verification: Verification = verificationDefinition;
 export type {Definition as default};
 export type {
 	About,
@@ -272,7 +292,9 @@ export type {
 	Store,
 	Tracker,
 	Trailer,
+	Unverification,
 	Update,
+	Verification,
 };
 export {
 	about,
@@ -296,5 +318,7 @@ export {
 	store,
 	tracker,
 	trailer,
+	unverification,
 	update,
+	verification,
 };

--- a/src/definitions/unverification.json
+++ b/src/definitions/unverification.json
@@ -1,0 +1,28 @@
+{
+	"commandName": "unverification",
+	"commandDescription": {
+		"en-US": "Refuses this member",
+		"fr": "Refuse ce membre",
+		"pt-BR": "Recusa esse membro"
+	},
+	"help": {
+		"en-US": "Press **$<commandMention>** to refuse a member",
+		"fr": "Appuie sur **$<commandMention>** pour refuser un membre",
+		"pt-BR": "Pressione **$<commandMention>** pra recusar um membro"
+	},
+	"reply": {
+		"en-US": "I have refused the member.",
+		"fr": "J'ai refusé le membre.",
+		"pt-BR": "Recusei o membro."
+	},
+	"noMemberReply": {
+		"en-US": "I do not know any member with this tag.",
+		"fr": "Je ne connais aucun membre avec cette étiquette.",
+		"pt-BR": "Não conheço nenhum membro com essa marcação."
+	},
+	"noPermissionReply": {
+		"en-US": "I do not have the rights to unverify this member.",
+		"fr": "Je n'ai pas les droits pour dévérifier ce membre.",
+		"pt-BR": "Eu não tenho as permissões pra desverificar esse membro."
+	}
+}

--- a/src/definitions/verification.json
+++ b/src/definitions/verification.json
@@ -1,0 +1,28 @@
+{
+	"commandName": "verification",
+	"commandDescription": {
+		"en-US": "Approves this member",
+		"fr": "Approuve ce membre",
+		"pt-BR": "Aprova esse membro"
+	},
+	"help": {
+		"en-US": "Press **$<commandMention>** to approve a member",
+		"fr": "Appuie sur **$<commandMention>** pour approuver un membre",
+		"pt-BR": "Pressione **$<commandMention>** pra aprovar um membro"
+	},
+	"reply": {
+		"en-US": "I have approved the member.",
+		"fr": "J'ai approuvé le membre.",
+		"pt-BR": "Aprovei o membro."
+	},
+	"noMemberReply": {
+		"en-US": "I do not know any member with this tag.",
+		"fr": "Je ne connais aucun membre avec cette étiquette.",
+		"pt-BR": "Não conheço nenhum membro com essa marcação."
+	},
+	"noPermissionReply": {
+		"en-US": "I do not have the rights to verify this member.",
+		"fr": "Je n'ai pas les droits pour vérifier ce membre.",
+		"pt-BR": "Eu não tenho as permissões pra verificar esse membro."
+	}
+}

--- a/src/dependencies.d.ts
+++ b/src/dependencies.d.ts
@@ -19,7 +19,9 @@ import type SoundtrackDependency from "./dependencies/soundtrack.js";
 import type StoreDependency from "./dependencies/store.js";
 import type TrackerDependency from "./dependencies/tracker.js";
 import type TrailerDependency from "./dependencies/trailer.js";
+import type UnverificationDependency from "./dependencies/unverification.js";
 import type UpdateDependency from "./dependencies/update.js";
+import type VerificationDependency from "./dependencies/verification.js";
 type About = AboutDependency;
 type Approval = ApprovalDependency;
 type Arrival = ArrivalDependency;
@@ -41,8 +43,10 @@ type Soundtrack = SoundtrackDependency;
 type Store = StoreDependency;
 type Tracker = TrackerDependency;
 type Trailer = TrailerDependency;
+type Unverification = UnverificationDependency;
 type Update = UpdateDependency;
-type Dependency = About | Approval | Arrival | Bear | Chat | Count | Departure | Emoji | Help | Leaderboard | Mission | Outfit | Raw | Record | Refusal | Roadmap | Rule7 | Soundtrack | Store | Tracker | Trailer | Update;
+type Verification = VerificationDependency;
+type Dependency = About | Approval | Arrival | Bear | Chat | Count | Departure | Emoji | Help | Leaderboard | Mission | Outfit | Raw | Record | Refusal | Roadmap | Rule7 | Soundtrack | Store | Tracker | Trailer | Update | Verification;
 export type {Dependency as default};
 export type {
 	About,
@@ -66,5 +70,7 @@ export type {
 	Store,
 	Tracker,
 	Trailer,
+	Unverification,
 	Update,
+	Verification,
 };

--- a/src/dependencies/unverification.d.ts
+++ b/src/dependencies/unverification.d.ts
@@ -1,0 +1,13 @@
+type HelpGroups = {
+	commandMention: () => string,
+};
+type ReplyGroups = {};
+type NoMemberReplyGroups = {};
+type NoPermissionReplyGroups = {};
+type UnverificationDependency = {
+	help: HelpGroups,
+	reply: ReplyGroups,
+	noMemberReply: NoMemberReplyGroups,
+	noPermissionReply: NoPermissionReplyGroups,
+};
+export type {UnverificationDependency as default};

--- a/src/dependencies/verification.d.ts
+++ b/src/dependencies/verification.d.ts
@@ -1,0 +1,13 @@
+type HelpGroups = {
+	commandMention: () => string,
+};
+type ReplyGroups = {};
+type NoMemberReplyGroups = {};
+type NoPermissionReplyGroups = {};
+type VerificationDependency = {
+	help: HelpGroups,
+	reply: ReplyGroups,
+	noMemberReply: NoMemberReplyGroups,
+	noPermissionReply: NoPermissionReplyGroups,
+};
+export type {VerificationDependency as default};

--- a/src/hooks/approval.ts
+++ b/src/hooks/approval.ts
@@ -15,7 +15,6 @@ import type Hook from "../hooks.js";
 import type {Webhook, WebhookData, WebjobInvocation} from "../hooks.js";
 import type {Localized} from "../utils/string.js";
 import {
-	ChannelType,
 	escapeMarkdown,
 } from "discord.js";
 import canvas from "canvas";
@@ -115,7 +114,7 @@ const approvalHook: Hook = {
 				content: approval,
 				username: applicationName,
 				avatarURL: applicationIcon,
-				...(channel != null && channel.type === ChannelType.GuildForum ? {threadName: welcome} : {}),
+				...(channel != null && channel.isThreadOnly() ? {threadName: welcome} : {}),
 				allowedMentions: {
 					parse: [],
 				},

--- a/src/hooks/refusal.ts
+++ b/src/hooks/refusal.ts
@@ -15,7 +15,6 @@ import type Hook from "../hooks.js";
 import type {Webhook, WebhookData, WebjobInvocation} from "../hooks.js";
 import type {Localized} from "../utils/string.js";
 import {
-	ChannelType,
 	escapeMarkdown,
 } from "discord.js";
 import canvas from "canvas";
@@ -115,7 +114,7 @@ const refusalHook: Hook = {
 				content: refusal,
 				username: applicationName,
 				avatarURL: applicationIcon,
-				...(channel != null && channel.type === ChannelType.GuildForum ? {threadName: farewell} : {}),
+				...(channel != null && channel.isThreadOnly() ? {threadName: farewell} : {}),
 				allowedMentions: {
 					parse: [],
 				},

--- a/src/shicka.ts
+++ b/src/shicka.ts
@@ -426,7 +426,7 @@ client.on("interactionCreate", async (interaction: Interaction): Promise<void> =
 	if (!interaction.inCachedGuild()) {
 		return;
 	}
-	if (!interaction.isAutocomplete() && !interaction.isChatInputCommand()) {
+	if (!interaction.isAutocomplete() && !interaction.isChatInputCommand() &&!interaction.isMessageContextMenuCommand()) {
 		return;
 	}
 	const {command}: ApplicationUserInteraction = interaction;
@@ -436,7 +436,7 @@ client.on("interactionCreate", async (interaction: Interaction): Promise<void> =
 	if (command.guild == null) {
 		return;
 	}
-	if (command.type !== ApplicationCommandType.ChatInput) {
+	if (command.type !== ApplicationCommandType.ChatInput && command.type !== ApplicationCommandType.Message) {
 		return;
 	}
 	const {client}: ApplicationCommand = command;


### PR DESCRIPTION
This is built on top of #70 but could be landed separately.
This adds two commands to add and / or remove `$SHICKA_REFUSAL_UNVERIFICATION_ROLE` and `$SHICKA_APPROVAL_VERIFICATION_ROLE` roles, to ease some parts of the current verification process.
Currently they are only implemented as message context menu commands and do not provide a way to specify a reason for using them.