### PR TITLE
Computes message groups eagerly

### DIFF
--- a/src/commands/about.ts
+++ b/src/commands/about.ts
@@ -41,15 +41,9 @@ const aboutCommand: Command = {
 		const resolvedLocale: Locale = resolve(locale);
 		function formatMessage(locale: Locale): string {
 			return replyLocalizations[locale]({
-				bot: (): string => {
-					return escapeMarkdown(bot);
-				},
-				author: (): string => {
-					return escapeMarkdown(author);
-				},
-				link: (): string => {
-					return link;
-				},
+				bot: escapeMarkdown(bot),
+				author: escapeMarkdown(author),
+				link: link,
 			});
 		}
 		await interaction.reply({
@@ -66,9 +60,7 @@ const aboutCommand: Command = {
 	describe(applicationCommand: ApplicationCommand): Localized<(groups: {}) => string> {
 		return composeAll<HelpGroups, {}>(helpLocalizations, localize<HelpGroups>((): HelpGroups => {
 			return {
-				commandMention: (): string => {
-					return `</${commandName}:${applicationCommand.id}>`;
-				},
+				commandMention: `</${commandName}:${applicationCommand.id}>`,
 			};
 		}));
 	},

--- a/src/commands/apply.ts
+++ b/src/commands/apply.ts
@@ -85,9 +85,7 @@ const applyCommand: Command = {
 	describe(applicationCommand: ApplicationCommand): Localized<(groups: {}) => string> {
 		return composeAll<HelpGroups, {}>(helpLocalizations, localize<HelpGroups>((): HelpGroups => {
 			return {
-				commandMention: (): string => {
-					return `</${commandName}:${applicationCommand.id}>`;
-				},
+				commandMention: `</${commandName}:${applicationCommand.id}>`,
 			};
 		}));
 	},

--- a/src/commands/approve.ts
+++ b/src/commands/approve.ts
@@ -120,9 +120,7 @@ const approveCommand: Command = {
 	describe(applicationCommand: ApplicationCommand): Localized<(groups: {}) => string> {
 		return composeAll<HelpGroups, {}>(helpLocalizations, localize<HelpGroups>((locale: Locale): HelpGroups => {
 			return {
-				commandMention: (): string => {
-					return commandDescription[locale];
-				},
+				commandMention: commandDescription[locale],
 			};
 		}));
 	},

--- a/src/commands/bear.ts
+++ b/src/commands/bear.ts
@@ -104,17 +104,13 @@ const bearCommand: Command = {
 		const coins: number | null = bear.id % 8 === 3 ? levels[bear.level].coins - 25 : 0;
 		const bossGoal: Localized<(groups: {}) => string> | null = boss != null ? composeAll<BossGoalGroups, {}>(bossGoalLocalizations, localize<BossGoalGroups>((locale: Locale): BossGoalGroups => {
 			return {
-				boss: (): string => {
-					return escapeMarkdown(boss[locale]);
-				},
+				boss: escapeMarkdown(boss[locale]),
 			};
 		})) : null;
 		const coinsGoal: Localized<(groups: {}) => string> | null = coins !== 0 ? composeAll<CoinsGoalGroups, {}>(bossGoal != null ? coinsWithBossGoalLocalizations : coinsWithoutBossGoalLocalizations, localize<CoinsGoalGroups>((locale: Locale): CoinsGoalGroups => {
 			const cardinalFormat: Intl.NumberFormat = new Intl.NumberFormat(locale);
 			return {
-				coins: (): string => {
-					return escapeMarkdown(cardinalFormat.format(coins));
-				},
+				coins: escapeMarkdown(cardinalFormat.format(coins)),
 			};
 		})) : null;
 		const minutes: string = `${gold / 60 | 0}`.padStart(2, "0");
@@ -123,9 +119,7 @@ const bearCommand: Command = {
 		const time: string = `${minutes}:${seconds}.${centiseconds}`;
 		const timeGoal: Localized<(groups: {}) => string> | null = time !== "00:00.00" ? composeAll<TimeGoalGroups, {}>(bossGoal != null || coinsGoal != null ? timeWithBossOrCoinsGoalLocalizations : timeWithoutBossAndCoinsGoalLocalizations, localize<TimeGoalGroups>((): TimeGoalGroups => {
 			return {
-				time: (): string => {
-					return escapeMarkdown(time);
-				},
+				time: escapeMarkdown(time),
 			};
 		})) : null;
 		const goals: Localized<(groups: {}) => string>[] = [bossGoal, coinsGoal, timeGoal].filter<Localized<(groups: {}) => string>>((goal: Localized<(groups: {}) => string> | null): goal is Localized<(groups: {}) => string> => {
@@ -137,22 +131,22 @@ const bearCommand: Command = {
 				type: "conjunction",
 			});
 			return replyLocalizations[locale]({
-				name: (): string => {
-					return escapeMarkdown(name[locale]);
-				},
-				level: (): string => {
-					return escapeMarkdown(level.name[locale]);
-				},
-				outfitNameConjunction: (): string => {
-					return bearOutfits.length !== 0 ? conjunctionFormat.format(bearOutfits.map<string>((outfit: Outfit): string => {
+				name: escapeMarkdown(name[locale]),
+				level: escapeMarkdown(level.name[locale]),
+				outfitNameConjunction: bearOutfits.length !== 0 ? (
+					conjunctionFormat.format(bearOutfits.map<string>((outfit: Outfit): string => {
 						return `*${escapeMarkdown(outfit.name[locale])}*`;
-					})) : escapeMarkdown(noOutfitLocalizations[locale]({}));
-				},
-				goalConjunction: (): string => {
-					return goals.length !== 0 ? conjunctionFormat.format(goals.map<string>((goal: Localized<(groups: {}) => string>): string => {
+					}))
+				) : (
+					escapeMarkdown(noOutfitLocalizations[locale]({}))
+				),
+				goalConjunction: goals.length !== 0 ? (
+					conjunctionFormat.format(goals.map<string>((goal: Localized<(groups: {}) => string>): string => {
 						return goal[locale]({});
-					})) : escapeMarkdown(noGoalLocalizations[locale]({}));
-				},
+					}))
+				) : (
+					escapeMarkdown(noGoalLocalizations[locale]({}))
+				),
 			});
 		}
 		await interaction.reply({
@@ -169,12 +163,8 @@ const bearCommand: Command = {
 	describe(applicationCommand: ApplicationCommand): Localized<(groups: {}) => string> {
 		return composeAll<HelpGroups, {}>(helpLocalizations, localize<HelpGroups>((locale: Locale): HelpGroups => {
 			return {
-				commandMention: (): string => {
-					return `</${commandName}:${applicationCommand.id}>`;
-				},
-				bearOptionDescription: (): string => {
-					return bearOptionDescription[locale];
-				},
+				commandMention: `</${commandName}:${applicationCommand.id}>`,
+				bearOptionDescription: bearOptionDescription[locale],
 			};
 		}));
 	},

--- a/src/commands/chat.ts
+++ b/src/commands/chat.ts
@@ -365,9 +365,7 @@ const chatCommand: Command = {
 				const max: number = attachments.length;
 				await interaction.reply({
 					content: noPositionReplyLocalizations[resolvedLocale]({
-						max: (): string => {
-							return escapeMarkdown(`${max}`);
-						},
+						max: escapeMarkdown(`${max}`),
 					}),
 					ephemeral: true,
 				});
@@ -408,9 +406,7 @@ const chatCommand: Command = {
 				const max: number = attachments.length - 1;
 				await interaction.reply({
 					content: noPositionReplyLocalizations[resolvedLocale]({
-						max: (): string => {
-							return escapeMarkdown(`${max}`);
-						},
+						max: escapeMarkdown(`${max}`),
 					}),
 					ephemeral: true,
 				});
@@ -453,33 +449,15 @@ const chatCommand: Command = {
 	describe(applicationCommand: ApplicationCommand): Localized<(groups: {}) => string> {
 		return composeAll<HelpGroups, {}>(helpLocalizations, localize<HelpGroups>((locale: Locale): HelpGroups => {
 			return {
-				postSubCommandMention: (): string => {
-					return `</${commandName} ${postSubCommandName}:${applicationCommand.id}>`;
-				},
-				patchSubCommandMention: (): string => {
-					return `</${commandName} ${patchSubCommandName}:${applicationCommand.id}>`;
-				},
-				attachSubCommandMention: (): string => {
-					return `</${commandName} ${attachSubCommandName}:${applicationCommand.id}>`;
-				},
-				detachSubCommandMention: (): string => {
-					return `</${commandName} ${detachSubCommandName}:${applicationCommand.id}>`;
-				},
-				channelOptionDescription: (): string => {
-					return channelOptionDescription[locale];
-				},
-				messageOptionDescription: (): string => {
-					return messageOptionDescription[locale];
-				},
-				contentOptionDescription: (): string => {
-					return contentOptionDescription[locale];
-				},
-				positionOptionDescription: (): string => {
-					return positionOptionDescription[locale];
-				},
-				attachmentOptionDescription: (): string => {
-					return attachmentOptionDescription[locale];
-				},
+				postSubCommandMention: `</${commandName} ${postSubCommandName}:${applicationCommand.id}>`,
+				patchSubCommandMention: `</${commandName} ${patchSubCommandName}:${applicationCommand.id}>`,
+				attachSubCommandMention: `</${commandName} ${attachSubCommandName}:${applicationCommand.id}>`,
+				detachSubCommandMention: `</${commandName} ${detachSubCommandName}:${applicationCommand.id}>`,
+				channelOptionDescription: channelOptionDescription[locale],
+				messageOptionDescription: messageOptionDescription[locale],
+				contentOptionDescription: contentOptionDescription[locale],
+				positionOptionDescription: positionOptionDescription[locale],
+				attachmentOptionDescription: attachmentOptionDescription[locale],
 			};
 		}));
 	},

--- a/src/commands/count.ts
+++ b/src/commands/count.ts
@@ -41,12 +41,8 @@ const countCommand: Command = {
 		function formatMessage(locale: Locale): string {
 			const cardinalFormat: Intl.NumberFormat = new Intl.NumberFormat(locale);
 			return replyLocalizations[locale]({
-				memberCount: (): string => {
-					return escapeMarkdown(cardinalFormat.format(memberCount));
-				},
-				name: (): string => {
-					return escapeMarkdown(name);
-				},
+				memberCount: escapeMarkdown(cardinalFormat.format(memberCount)),
+				name: escapeMarkdown(name),
 			});
 		}
 		await interaction.reply({
@@ -63,9 +59,7 @@ const countCommand: Command = {
 	describe(applicationCommand: ApplicationCommand): Localized<(groups: {}) => string> {
 		return composeAll<HelpGroups, {}>(helpLocalizations, localize<HelpGroups>((): HelpGroups => {
 			return {
-				commandMention: (): string => {
-					return `</${commandName}:${applicationCommand.id}>`;
-				},
+				commandMention: `</${commandName}:${applicationCommand.id}>`,
 			};
 		}));
 	},

--- a/src/commands/emoji.ts
+++ b/src/commands/emoji.ts
@@ -149,15 +149,9 @@ const emojiCommand: Command = {
 	describe(applicationCommand: ApplicationCommand): Localized<(groups: {}) => string> {
 		return composeAll<HelpGroups, {}>(helpLocalizations, localize<HelpGroups>((locale: Locale): HelpGroups => {
 			return {
-				commandMention: (): string => {
-					return `</${commandName}:${applicationCommand.id}>`;
-				},
-				baseOptionDescription: (): string => {
-					return baseOptionDescription[locale];
-				},
-				stylesOptionDescription: (): string => {
-					return stylesOptionDescription[locale];
-				},
+				commandMention: `</${commandName}:${applicationCommand.id}>`,
+				baseOptionDescription: baseOptionDescription[locale],
+				stylesOptionDescription: stylesOptionDescription[locale],
 			};
 		}));
 	},

--- a/src/commands/gate.ts
+++ b/src/commands/gate.ts
@@ -198,18 +198,10 @@ const gateCommand: Command = {
 	describe(applicationCommand: ApplicationCommand): Localized<(groups: {}) => string> {
 		return composeAll<HelpGroups, {}>(helpLocalizations, localize<HelpGroups>((locale: Locale): HelpGroups => {
 			return {
-				approveSubCommandMention: (): string => {
-					return `</${commandName} ${approveSubCommandName}:${applicationCommand.id}>`;
-				},
-				refuseSubCommandMention: (): string => {
-					return `</${commandName} ${refuseSubCommandName}:${applicationCommand.id}>`;
-				},
-				channelOptionDescription: (): string => {
-					return channelOptionDescription[locale];
-				},
-				messageOptionDescription: (): string => {
-					return messageOptionDescription[locale];
-				},
+				approveSubCommandMention: `</${commandName} ${approveSubCommandName}:${applicationCommand.id}>`,
+				refuseSubCommandMention: `</${commandName} ${refuseSubCommandName}:${applicationCommand.id}>`,
+				channelOptionDescription: channelOptionDescription[locale],
+				messageOptionDescription: messageOptionDescription[locale],
 			};
 		}));
 	},

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -323,12 +323,8 @@ const helpCommand: Command = {
 		});
 		function formatMessage(locale: Locale): string {
 			return replyLocalizations[locale]({
-				memberMention: (): string => {
-					return `<@${member.id}>`;
-				},
-				featureList: (): string => {
-					return list(features[locale]({}));
-				},
+				memberMention: `<@${member.id}>`,
+				featureList: list(features[locale]({})),
 			});
 		}
 		const persistentContent: string = formatMessage("en-US");
@@ -381,9 +377,7 @@ const helpCommand: Command = {
 	describe(applicationCommand: ApplicationCommand): Localized<(groups: {}) => string> {
 		return composeAll<HelpGroups, {}>(helpLocalizations, localize<HelpGroups>((): HelpGroups => {
 			return {
-				commandMention: (): string => {
-					return `</${commandName}:${applicationCommand.id}>`;
-				},
+				commandMention: `</${commandName}:${applicationCommand.id}>`,
 			};
 		}));
 	},

--- a/src/commands/leaderboard.ts
+++ b/src/commands/leaderboard.ts
@@ -88,23 +88,17 @@ const leaderboardCommand: Command = {
 		for (const item of data) {
 			const link: Localized<(groups: {}) => string> = composeAll<LinkGroups, {}>(linkLocalizations, localize<LinkGroups>((): LinkGroups => {
 				return {
-					title: (): string => {
-						return escapeMarkdown(item.title);
-					},
-					link: (): string => {
-						return item.link;
-					},
+					title: escapeMarkdown(item.title),
+					link: item.link,
 				};
 			}));
 			links.push(link);
 		}
 		function formatMessage(locale: Locale): string {
 			return replyLocalizations[locale]({
-				linkList: (): string => {
-					return list(links.map<string>((link: Localized<(groups: {}) => string>): string => {
-						return link[locale]({});
-					}));
-				},
+				linkList: list(links.map<string>((link: Localized<(groups: {}) => string>): string => {
+					return link[locale]({});
+				})),
 			});
 		}
 		await interaction.reply({
@@ -121,9 +115,7 @@ const leaderboardCommand: Command = {
 	describe(applicationCommand: ApplicationCommand): Localized<(groups: {}) => string> {
 		return composeAll<HelpGroups, {}>(helpLocalizations, localize<HelpGroups>((): HelpGroups => {
 			return {
-				commandMention: (): string => {
-					return `</${commandName}:${applicationCommand.id}>`;
-				},
+				commandMention: `</${commandName}:${applicationCommand.id}>`,
 			};
 		}));
 	},

--- a/src/commands/mission.ts
+++ b/src/commands/mission.ts
@@ -69,12 +69,8 @@ const missionCommand: Command = {
 				const challenge: Challenge = challenges[mission.challenge];
 				const level: Level = levels[mission.level];
 				const missionName: string = missionNameLocalizations[resolvedLocale]({
-					challengeName: (): string => {
-						return challenge.name[resolvedLocale];
-					},
-					levelName: (): string => {
-						return level.name[resolvedLocale];
-					},
+					challengeName: challenge.name[resolvedLocale],
+					levelName: level.name[resolvedLocale],
 				});
 				return missionName.toLocaleLowerCase(resolvedLocale);
 			});
@@ -83,12 +79,8 @@ const missionCommand: Command = {
 				const challenge: Challenge = challenges[mission.challenge];
 				const level: Level = levels[mission.level];
 				const missionName: string = missionNameLocalizations[resolvedLocale]({
-					challengeName: (): string => {
-						return challenge.name[resolvedLocale];
-					},
-					levelName: (): string => {
-						return level.name[resolvedLocale];
-					},
+					challengeName: challenge.name[resolvedLocale],
+					levelName: level.name[resolvedLocale],
 				});
 				return {
 					name: missionName,
@@ -121,15 +113,9 @@ const missionCommand: Command = {
 					timeZone: "UTC",
 				});
 				return {
-					dayDate: (): string => {
-						return escapeMarkdown(dateFormat.format(dayDate));
-					},
-					challengeName: (): string => {
-						return escapeMarkdown(challenge.name[locale]);
-					},
-					levelName: (): string => {
-						return escapeMarkdown(level.name[locale]);
-					},
+					dayDate: escapeMarkdown(dateFormat.format(dayDate)),
+					challengeName: escapeMarkdown(challenge.name[locale]),
+					levelName: escapeMarkdown(level.name[locale]),
 				};
 			}));
 			schedules.push(schedule);
@@ -140,14 +126,10 @@ const missionCommand: Command = {
 				timeZone: "UTC",
 			});
 			return bareReplyLocalizations[locale]({
-				dayTime: (): string => {
-					return escapeMarkdown(timeFormat.format(dayTime));
-				},
-				scheduleList: (): string => {
-					return list(schedules.map<string>((schedule: Localized<(groups: {}) => string>): string => {
-						return schedule[locale]({})
-					}));
-				},
+				dayTime: escapeMarkdown(timeFormat.format(dayTime)),
+				scheduleList: list(schedules.map<string>((schedule: Localized<(groups: {}) => string>): string => {
+					return schedule[locale]({})
+				})),
 			});
 		}
 		await interaction.reply({
@@ -176,9 +158,7 @@ const missionCommand: Command = {
 						timeZone: "UTC",
 					});
 					return {
-						dayDateTime: (): string => {
-							return escapeMarkdown(dateTimeFormat.format(dayDateTime));
-						},
+						dayDateTime: escapeMarkdown(dateTimeFormat.format(dayDateTime)),
 					};
 				}));
 				schedules.push(schedule);
@@ -188,17 +168,11 @@ const missionCommand: Command = {
 		const level: Level = levels[mission.level];
 		function formatMessage(locale: Locale): string {
 			return replyLocalizations[locale]({
-				challengeName: (): string => {
-					return escapeMarkdown(challenge.name[locale]);
-				},
-				levelName: (): string => {
-					return escapeMarkdown(level.name[locale]);
-				},
-				scheduleList: (): string => {
-					return list(schedules.map<string>((schedule: Localized<(groups: {}) => string>): string => {
-						return schedule[locale]({})
-					}));
-				},
+				challengeName: escapeMarkdown(challenge.name[locale]),
+				levelName: escapeMarkdown(level.name[locale]),
+				scheduleList: list(schedules.map<string>((schedule: Localized<(groups: {}) => string>): string => {
+					return schedule[locale]({})
+				})),
 			});
 		}
 		await interaction.reply({
@@ -215,12 +189,8 @@ const missionCommand: Command = {
 	describe(applicationCommand: ApplicationCommand): Localized<(groups: {}) => string> {
 		return composeAll<HelpGroups, {}>(helpLocalizations, localize<HelpGroups>((locale: Locale): HelpGroups => {
 			return {
-				commandMention: (): string => {
-					return `</${commandName}:${applicationCommand.id}>`;
-				},
-				missionOptionDescription: (): string => {
-					return missionOptionDescription[locale];
-				},
+				commandMention: `</${commandName}:${applicationCommand.id}>`,
+				missionOptionDescription: missionOptionDescription[locale],
 			};
 		}));
 	},

--- a/src/commands/outfit.ts
+++ b/src/commands/outfit.ts
@@ -195,25 +195,19 @@ const outfitCommand: Command = {
 					type: "conjunction",
 				});
 				return {
-					dayDateTime: (): string => {
-						return escapeMarkdown(dateTimeFormat.format(dayDateTime));
-					},
-					outfitNameConjunction: (): string => {
-						return conjunctionFormat.format(scheduleOutfits.map<string>((outfit: Outfit): string => {
-							return `**${escapeMarkdown(outfit.name[locale])}**`;
-						}));
-					},
+					dayDateTime: escapeMarkdown(dateTimeFormat.format(dayDateTime)),
+					outfitNameConjunction: conjunctionFormat.format(scheduleOutfits.map<string>((outfit: Outfit): string => {
+						return `**${escapeMarkdown(outfit.name[locale])}**`;
+					})),
 				};
 			}));
 			schedules.push(schedule);
 		}
 		function formatMessage(locale: Locale): string {
 			return bareReplyLocalizations[locale]({
-				scheduleList: (): string => {
-					return list(schedules.map<string>((schedule: Localized<(groups: {}) => string>): string => {
-						return schedule[locale]({});
-					}));
-				},
+				scheduleList: list(schedules.map<string>((schedule: Localized<(groups: {}) => string>): string => {
+					return schedule[locale]({});
+				})),
 			});
 		}
 		await interaction.reply({
@@ -232,9 +226,7 @@ const outfitCommand: Command = {
 		if (rarities[outfit.rarity].slots === 0) {
 			function formatMessage(locale: Locale): string {
 				return noSlotReplyLocalizations[locale]({
-					outfitName: (): string => {
-						return escapeMarkdown(outfit.name[locale]);
-					},
+					outfitName: escapeMarkdown(outfit.name[locale]),
 				});
 			}
 			await interaction.reply({
@@ -272,9 +264,7 @@ const outfitCommand: Command = {
 						timeZone: "UTC",
 					});
 					return {
-						dayDateTime: (): string => {
-							return escapeMarkdown(dateTimeFormat.format(dayDateTime));
-						},
+						dayDateTime: escapeMarkdown(dateTimeFormat.format(dayDateTime)),
 					};
 				}));
 				schedules.push(schedule);
@@ -284,18 +274,14 @@ const outfitCommand: Command = {
 		const tokensCost: Localized<(groups: {}) => string> | null = tokens !== 0 ? composeAll<TokensCostGroups, {}>(tokensCostLocalizations, localize<TokensCostGroups>((locale: Locale): TokensCostGroups => {
 			const cardinalFormat: Intl.NumberFormat = new Intl.NumberFormat(locale);
 			return {
-				tokens: (): string => {
-					return escapeMarkdown(cardinalFormat.format(tokens));
-				},
+				tokens: escapeMarkdown(cardinalFormat.format(tokens)),
 			};
 		})) : null;
 		const coins: number = rarities[outfit.rarity].cost;
 		const coinsCost: Localized<(groups: {}) => string> | null = coins !== 0 ? composeAll<CoinsCostGroups, {}>(coinsCostLocalizations, localize<CoinsCostGroups>((locale: Locale): CoinsCostGroups => {
 			const cardinalFormat: Intl.NumberFormat = new Intl.NumberFormat(locale);
 			return {
-				coins: (): string => {
-					return escapeMarkdown(cardinalFormat.format(coins));
-				},
+				coins: escapeMarkdown(cardinalFormat.format(coins)),
 			};
 		})) : null;
 		const costs: Localized<(groups: {}) => string>[] = [tokensCost, coinsCost].filter<Localized<(groups: {}) => string>>((cost: Localized<(groups: {}) => string> | null): cost is Localized<(groups: {}) => string> => {
@@ -307,19 +293,17 @@ const outfitCommand: Command = {
 				type: "conjunction",
 			});
 			return replyLocalizations[locale]({
-				outfitName: (): string => {
-					return escapeMarkdown(outfit.name[locale]);
-				},
-				costConjunction: (): string => {
-					return costs.length !== 0 ? conjunctionFormat.format(costs.map<string>((cost: Localized<(groups: {}) => string>): string => {
+				outfitName: escapeMarkdown(outfit.name[locale]),
+				costConjunction: costs.length !== 0 ? (
+					conjunctionFormat.format(costs.map<string>((cost: Localized<(groups: {}) => string>): string => {
 						return cost[locale]({});
-					})) : escapeMarkdown(noCostLocalizations[locale]({}));
-				},
-				scheduleList: (): string => {
-					return list(schedules.map<string>((schedule: Localized<(groups: {}) => string>): string => {
-						return schedule[locale]({})
-					}));
-				},
+					}))
+				) : (
+					escapeMarkdown(noCostLocalizations[locale]({}))
+				),
+				scheduleList: list(schedules.map<string>((schedule: Localized<(groups: {}) => string>): string => {
+					return schedule[locale]({})
+				})),
 			});
 		}
 		await interaction.reply({
@@ -336,12 +320,8 @@ const outfitCommand: Command = {
 	describe(applicationCommand: ApplicationCommand): Localized<(groups: {}) => string> {
 		return composeAll<HelpGroups, {}>(helpLocalizations, localize<HelpGroups>((locale: Locale): HelpGroups => {
 			return {
-				commandMention: (): string => {
-					return `</${commandName}:${applicationCommand.id}>`;
-				},
-				outfitOptionDescription: (): string => {
-					return outfitOptionDescription[locale];
-				},
+				commandMention: `</${commandName}:${applicationCommand.id}>`,
+				outfitOptionDescription: outfitOptionDescription[locale],
 			};
 		}));
 	},

--- a/src/commands/patch.ts
+++ b/src/commands/patch.ts
@@ -115,9 +115,7 @@ const patchCommand: Command = {
 	describe(applicationCommand: ApplicationCommand): Localized<(groups: {}) => string> {
 		return composeAll<HelpGroups, {}>(helpLocalizations, localize<HelpGroups>((locale: Locale): HelpGroups => {
 			return {
-				commandMention: (): string => {
-					return commandDescription[locale];
-				},
+				commandMention: commandDescription[locale],
 			};
 		}));
 	},

--- a/src/commands/raw.ts
+++ b/src/commands/raw.ts
@@ -81,11 +81,9 @@ const rawCommand: Command = {
 			});
 			await interaction.reply({
 				content: noTypeReplyLocalizations[resolvedLocale]({
-					typeConjunction: (): string => {
-						return conjunctionFormat.format(Object.keys(bindings).map<string>((bindingName: string): string => {
-							return `\`${escapeMarkdown(bindingName)}\``;
-						}));
-					},
+					typeConjunction: conjunctionFormat.format(Object.keys(bindings).map<string>((bindingName: string): string => {
+						return `\`${escapeMarkdown(bindingName)}\``;
+						})),
 				}),
 				ephemeral: true,
 			});
@@ -97,9 +95,7 @@ const rawCommand: Command = {
 			const max: number = binding.length - 1;
 			await interaction.reply({
 				content: noIdentifierReplyLocalizations[resolvedLocale]({
-					max: (): string => {
-						return escapeMarkdown(`${max}`);
-					},
+					max: escapeMarkdown(`${max}`),
 				}),
 				ephemeral: true,
 			});
@@ -113,15 +109,9 @@ const rawCommand: Command = {
 	describe(applicationCommand: ApplicationCommand): Localized<(groups: {}) => string> {
 		return composeAll<HelpGroups, {}>(helpLocalizations, localize<HelpGroups>((locale: Locale): HelpGroups => {
 			return {
-				commandMention: (): string => {
-					return `</${commandName}:${applicationCommand.id}>`;
-				},
-				typeOptionDescription: (): string => {
-					return typeOptionDescription[locale];
-				},
-				identifierOptionDescription: (): string => {
-					return identifierOptionDescription[locale];
-				},
+				commandMention: `</${commandName}:${applicationCommand.id}>`,
+				typeOptionDescription: typeOptionDescription[locale],
+				identifierOptionDescription: identifierOptionDescription[locale],
 			};
 		}));
 	},

--- a/src/commands/refuse.ts
+++ b/src/commands/refuse.ts
@@ -120,9 +120,7 @@ const refuseCommand: Command = {
 	describe(applicationCommand: ApplicationCommand): Localized<(groups: {}) => string> {
 		return composeAll<HelpGroups, {}>(helpLocalizations, localize<HelpGroups>((locale: Locale): HelpGroups => {
 			return {
-				commandMention: (): string => {
-					return commandDescription[locale];
-				},
+				commandMention: commandDescription[locale],
 			};
 		}));
 	},

--- a/src/commands/roadmap.ts
+++ b/src/commands/roadmap.ts
@@ -55,16 +55,10 @@ const roadmapCommand: Command = {
 		})();
 		function formatMessage(locale: Locale): string {
 			return replyLocalizations[locale]({
-				intent: (): string => {
-					return channel != null ? intentWithChannelLocalizations[locale]({
-						channelMention: (): string => {
-							return `<#${channel.id}>`;
-						},
-					}) : intentWithoutChannelLocalizations[locale]({});
-				},
-				link: (): string => {
-					return link;
-				},
+				intent: channel != null ? intentWithChannelLocalizations[locale]({
+					channelMention: `<#${channel.id}>`,
+				}) : intentWithoutChannelLocalizations[locale]({}),
+				link: link,
 			});
 		}
 		await interaction.reply({
@@ -81,9 +75,7 @@ const roadmapCommand: Command = {
 	describe(applicationCommand: ApplicationCommand): Localized<(groups: {}) => string> {
 		return composeAll<HelpGroups, {}>(helpLocalizations, localize<HelpGroups>((): HelpGroups => {
 			return {
-				commandMention: (): string => {
-					return `</${commandName}:${applicationCommand.id}>`;
-				},
+				commandMention: `</${commandName}:${applicationCommand.id}>`,
 			};
 		}));
 	},

--- a/src/commands/soundtrack.ts
+++ b/src/commands/soundtrack.ts
@@ -96,26 +96,18 @@ const soundtrackCommand: Command = {
 			for (const item of data) {
 				const link: Localized<(groups: {}) => string> = composeAll<LinkGroups, {}>(linkLocalizations, localize<LinkGroups>((): LinkGroups => {
 					return {
-						title: (): string => {
-							return escapeMarkdown(item.title);
-						},
-						link: (): string => {
-							return item.link;
-						},
-						views: (): string => {
-							return escapeMarkdown(item.views);
-						},
+						title: escapeMarkdown(item.title),
+						link: item.link,
+						views: escapeMarkdown(item.views),
 					};
 				}));
 				links.push(link);
 			}
 			function formatMessage(locale: Locale): string {
 				return replyLocalizations[locale]({
-					linkList: (): string => {
-						return list(links.map<string>((link: Localized<(groups: {}) => string>): string => {
-							return link[locale]({});
-						}));
-					},
+					linkList: list(links.map<string>((link: Localized<(groups: {}) => string>): string => {
+						return link[locale]({});
+					})),
 				});
 			}
 			await interaction.reply({
@@ -132,9 +124,7 @@ const soundtrackCommand: Command = {
 			console.warn(error);
 			function formatMessage(locale: Locale): string {
 				return defaultReplyLocalizations[locale]({
-					link: (): string => {
-						return link;
-					},
+					link: link,
 				});
 			}
 			await interaction.reply({
@@ -152,9 +142,7 @@ const soundtrackCommand: Command = {
 	describe(applicationCommand: ApplicationCommand): Localized<(groups: {}) => string> {
 		return composeAll<HelpGroups, {}>(helpLocalizations, localize<HelpGroups>((): HelpGroups => {
 			return {
-				commandMention: (): string => {
-					return `</${commandName}:${applicationCommand.id}>`;
-				},
+				commandMention: `</${commandName}:${applicationCommand.id}>`,
 			};
 		}));
 	},

--- a/src/commands/store.ts
+++ b/src/commands/store.ts
@@ -64,23 +64,17 @@ const storeCommand: Command = {
 		for (const item of data) {
 			const link: Localized<(groups: {}) => string> = composeAll<LinkGroups, {}>(linkLocalizations, localize<LinkGroups>((locale: Locale): LinkGroups => {
 				return {
-					title: (): string => {
-						return escapeMarkdown(item.title[locale]);
-					},
-					link: (): string => {
-						return item.link;
-					},
+					title: escapeMarkdown(item.title[locale]),
+					link: item.link,
 				};
 			}));
 			links.push(link);
 		}
 		function formatMessage(locale: Locale): string {
 			return replyLocalizations[locale]({
-				linkList: (): string => {
-					return list(links.map<string>((link: Localized<(groups: {}) => string>): string => {
-						return link[locale]({});
-					}));
-				},
+				linkList: list(links.map<string>((link: Localized<(groups: {}) => string>): string => {
+					return link[locale]({});
+				})),
 			});
 		}
 		await interaction.reply({
@@ -97,9 +91,7 @@ const storeCommand: Command = {
 	describe(applicationCommand: ApplicationCommand): Localized<(groups: {}) => string> {
 		return composeAll<HelpGroups, {}>(helpLocalizations, localize<HelpGroups>((): HelpGroups => {
 			return {
-				commandMention: (): string => {
-					return `</${commandName}:${applicationCommand.id}>`;
-				},
+				commandMention: `</${commandName}:${applicationCommand.id}>`,
 			};
 		}));
 	},

--- a/src/commands/tracker.ts
+++ b/src/commands/tracker.ts
@@ -81,30 +81,20 @@ const trackerCommand: Command = {
 		for (const item of data) {
 			const link: Localized<(groups: {}) => string> = composeAll<LinkGroups, {}>(linkLocalizations, localize<LinkGroups>((locale: Locale): LinkGroups => {
 				return {
-					title: (): string => {
-						return escapeMarkdown(item.title[locale]);
-					},
-					link: (): string => {
-						return item.link;
-					},
+					title: escapeMarkdown(item.title[locale]),
+					link: item.link,
 				};
 			}));
 			links.push(link);
 		}
 		function formatMessage(locale: Locale): string {
 			return replyLocalizations[locale]({
-				intent: (): string => {
-					return channel != null ? intentWithChannelLocalizations[locale]({
-						channelMention: (): string => {
-							return `<#${channel.id}>`;
-						},
-					}) : intentWithoutChannelLocalizations[locale]({});
-				},
-				linkList: (): string => {
-					return list(links.map<string>((link: Localized<(groups: {}) => string>): string => {
-						return link[locale]({});
-					}));
-				},
+				intent: channel != null ? intentWithChannelLocalizations[locale]({
+					channelMention: `<#${channel.id}>`,
+				}) : intentWithoutChannelLocalizations[locale]({}),
+				linkList: list(links.map<string>((link: Localized<(groups: {}) => string>): string => {
+					return link[locale]({});
+				})),
 			});
 		}
 		await interaction.reply({
@@ -121,9 +111,7 @@ const trackerCommand: Command = {
 	describe(applicationCommand: ApplicationCommand): Localized<(groups: {}) => string> {
 		return composeAll<HelpGroups, {}>(helpLocalizations, localize<HelpGroups>((): HelpGroups => {
 			return {
-				commandMention: (): string => {
-					return `</${commandName}:${applicationCommand.id}>`;
-				},
+				commandMention: `</${commandName}:${applicationCommand.id}>`,
 			};
 		}));
 	},

--- a/src/commands/trailer.ts
+++ b/src/commands/trailer.ts
@@ -99,26 +99,18 @@ const trailerCommand: Command = {
 			for (const item of data) {
 				const link: Localized<(groups: {}) => string> = composeAll<LinkGroups, {}>(linkLocalizations, localize<LinkGroups>((): LinkGroups => {
 					return {
-						title: (): string => {
-							return escapeMarkdown(item.title);
-						},
-						link: (): string => {
-							return item.link;
-						},
-						views: (): string => {
-							return escapeMarkdown(item.views);
-						},
+						title: escapeMarkdown(item.title),
+						link: item.link,
+						views: escapeMarkdown(item.views),
 					};
 				}));
 				links.push(link);
 			}
 			function formatMessage(locale: Locale): string {
 				return replyLocalizations[locale]({
-					linkList: (): string => {
-						return list(links.map<string>((link: Localized<(groups: {}) => string>): string => {
-							return link[locale]({});
-						}));
-					},
+					linkList: list(links.map<string>((link: Localized<(groups: {}) => string>): string => {
+						return link[locale]({});
+					})),
 				});
 			}
 			await interaction.reply({
@@ -135,9 +127,7 @@ const trailerCommand: Command = {
 			console.warn(error);
 			function formatMessage(locale: Locale): string {
 				return defaultReplyLocalizations[locale]({
-					link: (): string => {
-						return link;
-					},
+					link: link,
 				});
 			}
 			await interaction.reply({
@@ -155,9 +145,7 @@ const trailerCommand: Command = {
 	describe(applicationCommand: ApplicationCommand): Localized<(groups: {}) => string> {
 		return composeAll<HelpGroups, {}>(helpLocalizations, localize<HelpGroups>((): HelpGroups => {
 			return {
-				commandMention: (): string => {
-					return `</${commandName}:${applicationCommand.id}>`;
-				},
+				commandMention: `</${commandName}:${applicationCommand.id}>`,
 			};
 		}));
 	},

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -145,29 +145,19 @@ const updateCommand: Command = {
 						timeZone: "UTC",
 					});
 					return {
-						title: (): string => {
-							return escapeMarkdown(item.title);
-						},
-						link: (): string => {
-							return item.link;
-						},
-						date: (): string => {
-							return escapeMarkdown(dateFormat.format(item.date));
-						},
-						version: (): string => {
-							return escapeMarkdown(item.version);
-						},
+						title: escapeMarkdown(item.title),
+						link: item.link,
+						date: escapeMarkdown(dateFormat.format(item.date)),
+						version: escapeMarkdown(item.version),
 					};
 				}));
 				links.push(link);
 			}
 			function formatMessage(locale: Locale): string {
 				return replyLocalizations[locale]({
-					linkList: (): string => {
-						return list(links.map<string>((link: Localized<(groups: {}) => string>): string => {
-							return link[locale]({});
-						}));
-					},
+					linkList: list(links.map<string>((link: Localized<(groups: {}) => string>): string => {
+						return link[locale]({});
+					})),
 				});
 			}
 			await interaction.reply({
@@ -185,9 +175,7 @@ const updateCommand: Command = {
 			const linkList: string = list(links);
 			function formatMessage(locale: Locale): string {
 				return defaultReplyLocalizations[locale]({
-					linkList: (): string => {
-						return linkList;
-					},
+					linkList: linkList,
 				});
 			}
 			await interaction.reply({
@@ -205,9 +193,7 @@ const updateCommand: Command = {
 	describe(applicationCommand: ApplicationCommand): Localized<(groups: {}) => string> {
 		return composeAll<HelpGroups, {}>(helpLocalizations, localize<HelpGroups>((): HelpGroups => {
 			return {
-				commandMention: (): string => {
-					return `</${commandName}:${applicationCommand.id}>`;
-				},
+				commandMention: `</${commandName}:${applicationCommand.id}>`,
 			};
 		}));
 	},

--- a/src/commands/verify.ts
+++ b/src/commands/verify.ts
@@ -71,9 +71,7 @@ const verifyCommand: Command = {
 		}
 		function formatMessage(locale: Locale): string {
 			return replyLocalizations[locale]({
-				name: (): string => {
-					return escapeMarkdown(name);
-				},
+				name: escapeMarkdown(name),
 			});
 		}
 		await interaction.reply({
@@ -91,9 +89,7 @@ const verifyCommand: Command = {
 	describe(applicationCommand: ApplicationCommand): Localized<(groups: {}) => string> {
 		return composeAll<HelpGroups, {}>(helpLocalizations, localize<HelpGroups>((): HelpGroups => {
 			return {
-				commandMention: (): string => {
-					return `</${commandName}:${applicationCommand.id}>`;
-				},
+				commandMention: `</${commandName}:${applicationCommand.id}>`,
 			};
 		}));
 	},

--- a/src/dependencies/about.d.ts
+++ b/src/dependencies/about.d.ts
@@ -1,10 +1,10 @@
 type HelpGroups = {
-	commandMention: () => string,
+	commandMention: string,
 };
 type ReplyGroups = {
-	bot: () => string,
-	author: () => string,
-	link: () => string,
+	bot: string,
+	author: string,
+	link: string,
 };
 type AboutDependency = {
 	help: HelpGroups,

--- a/src/dependencies/application.d.ts
+++ b/src/dependencies/application.d.ts
@@ -1,5 +1,5 @@
 type HelpWithChannelGroups = {
-	channelMention: () => string,
+	channelMention: string,
 };
 type HelpWithoutChannelGroups = {};
 type ApplicationDependency = {

--- a/src/dependencies/apply.d.ts
+++ b/src/dependencies/apply.d.ts
@@ -1,5 +1,5 @@
 type HelpGroups = {
-	commandMention: () => string,
+	commandMention: string,
 };
 type ReplyGroups = {};
 type NoPermissionReplyGroups = {};

--- a/src/dependencies/approval.d.ts
+++ b/src/dependencies/approval.d.ts
@@ -1,5 +1,5 @@
 type HelpWithChannelGroups = {
-	channelMention: () => string,
+	channelMention: string,
 };
 type HelpWithoutChannelGroups = {};
 type ApprovalDependency = {

--- a/src/dependencies/approve.d.ts
+++ b/src/dependencies/approve.d.ts
@@ -1,5 +1,5 @@
 type HelpGroups = {
-	commandMention: () => string,
+	commandMention: string,
 };
 type ReplyGroups = {};
 type NoMemberReplyGroups = {};

--- a/src/dependencies/arrival.d.ts
+++ b/src/dependencies/arrival.d.ts
@@ -1,9 +1,9 @@
 type HelpWithChannelGroups = {
-	channelMention: () => string,
+	channelMention: string,
 };
 type HelpWithoutChannelGroups = {};
 type GreetingGroups = {
-	memberMention: () => string,
+	memberMention: string,
 };
 type ArrivalDependency = {
 	helpWithChannel: HelpWithChannelGroups,

--- a/src/dependencies/bear.d.ts
+++ b/src/dependencies/bear.d.ts
@@ -1,22 +1,22 @@
 type HelpGroups = {
-	commandMention: () => string,
-	bearOptionDescription: () => string,
+	commandMention: string,
+	bearOptionDescription: string,
 };
 type ReplyGroups = {
-	name: () => string,
-	level: () => string,
-	outfitNameConjunction: () => string,
-	goalConjunction: () => string,
+	name: string,
+	level: string,
+	outfitNameConjunction: string,
+	goalConjunction: string,
 };
 type NoOutfitGroups = {};
 type BossGoalGroups = {
-	boss: () => string,
+	boss: string,
 };
 type CoinsGoalGroups = {
-	coins: () => string,
+	coins: string,
 };
 type TimeGoalGroups = {
-	time: () => string,
+	time: string,
 };
 type NoGoalGroups = {};
 type BearDependency = {

--- a/src/dependencies/chat.d.ts
+++ b/src/dependencies/chat.d.ts
@@ -1,20 +1,20 @@
 type HelpGroups = {
-	postSubCommandMention: () => string,
-	patchSubCommandMention: () => string,
-	attachSubCommandMention: () => string,
-	detachSubCommandMention: () => string,
-	channelOptionDescription: () => string,
-	messageOptionDescription: () => string,
-	contentOptionDescription: () => string,
-	positionOptionDescription: () => string,
-	attachmentOptionDescription: () => string,
+	postSubCommandMention: string,
+	patchSubCommandMention: string,
+	attachSubCommandMention: string,
+	detachSubCommandMention: string,
+	channelOptionDescription: string,
+	messageOptionDescription: string,
+	contentOptionDescription: string,
+	positionOptionDescription: string,
+	attachmentOptionDescription: string,
 };
 type ReplyGroups = {};
 type BareReplyGroups = {};
 type NoChannelReplyGroups = {};
 type NoMessageReplyGroups = {};
 type NoPositionReplyGroups = {
-	max: () => string,
+	max: string,
 };
 type NoContentOrAttachmentReplyGroups = {};
 type NoInteractionReplyGroups = {};

--- a/src/dependencies/count.d.ts
+++ b/src/dependencies/count.d.ts
@@ -1,9 +1,9 @@
 type HelpGroups = {
-	commandMention: () => string,
+	commandMention: string,
 };
 type ReplyGroups = {
-	memberCount: () => string,
-	name: () => string,
+	memberCount: string,
+	name: string,
 };
 type CountDependency = {
 	help: HelpGroups,

--- a/src/dependencies/departure.d.ts
+++ b/src/dependencies/departure.d.ts
@@ -1,9 +1,9 @@
 type HelpWithChannelGroups = {
-	channelMention: () => string,
+	channelMention: string,
 };
 type HelpWithoutChannelGroups = {};
 type GreetingGroups = {
-	memberMention: () => string,
+	memberMention: string,
 };
 type DepartureDependency = {
 	helpWithChannel: HelpWithChannelGroups,

--- a/src/dependencies/emoji.d.ts
+++ b/src/dependencies/emoji.d.ts
@@ -1,7 +1,7 @@
 type HelpGroups = {
-	commandMention: () => string,
-	baseOptionDescription: () => string,
-	stylesOptionDescription: () => string,
+	commandMention: string,
+	baseOptionDescription: string,
+	stylesOptionDescription: string,
 };
 type EmojiDependency = {
 	help: HelpGroups,

--- a/src/dependencies/gate.d.ts
+++ b/src/dependencies/gate.d.ts
@@ -1,8 +1,8 @@
 type HelpGroups = {
-	approveSubCommandMention: () => string,
-	refuseSubCommandMention: () => string,
-	channelOptionDescription: () => string,
-	messageOptionDescription: () => string,
+	approveSubCommandMention: string,
+	refuseSubCommandMention: string,
+	channelOptionDescription: string,
+	messageOptionDescription: string,
 };
 type NoChannelReplyGroups = {};
 type NoMessageReplyGroups = {};

--- a/src/dependencies/help.d.ts
+++ b/src/dependencies/help.d.ts
@@ -1,9 +1,9 @@
 type HelpGroups = {
-	commandMention: () => string,
+	commandMention: string,
 };
 type ReplyGroups = {
-	memberMention: () => string,
-	featureList: () => string,
+	memberMention: string,
+	featureList: string,
 };
 type HelpDependency = {
 	help: HelpGroups,

--- a/src/dependencies/leaderboard.d.ts
+++ b/src/dependencies/leaderboard.d.ts
@@ -1,12 +1,12 @@
 type HelpGroups = {
-	commandMention: () => string,
+	commandMention: string,
 };
 type ReplyGroups = {
-	linkList: () => string,
+	linkList: string,
 };
 type LinkGroups = {
-	title: () => string,
-	link: () => string,
+	title: string,
+	link: string,
 };
 type LeaderboardDependency = {
 	help: HelpGroups,

--- a/src/dependencies/mission.d.ts
+++ b/src/dependencies/mission.d.ts
@@ -1,27 +1,27 @@
 type HelpGroups = {
-	commandMention: () => string,
-	missionOptionDescription: () => string,
+	commandMention: string,
+	missionOptionDescription: string,
 };
 type ReplyGroups = {
-	challengeName: () => string,
-	levelName: () => string,
-	scheduleList: () => string,
+	challengeName: string,
+	levelName: string,
+	scheduleList: string,
 };
 type BareReplyGroups = {
-	dayTime: () => string,
-	scheduleList: () => string,
+	dayTime: string,
+	scheduleList: string,
 };
 type MissionNameGroups = {
-	challengeName: () => string,
-	levelName: () => string,
+	challengeName: string,
+	levelName: string,
 };
 type ScheduleGroups = {
-	dayDateTime: () => string,
+	dayDateTime: string,
 };
 type BareScheduleGroups = {
-	dayDate: () => string,
-	challengeName: () => string,
-	levelName: () => string,
+	dayDate: string,
+	challengeName: string,
+	levelName: string,
 };
 type MissionDependency = {
 	help: HelpGroups,

--- a/src/dependencies/outfit.d.ts
+++ b/src/dependencies/outfit.d.ts
@@ -1,31 +1,31 @@
 type HelpGroups = {
-	commandMention: () => string,
-	outfitOptionDescription: () => string,
+	commandMention: string,
+	outfitOptionDescription: string,
 };
 type ReplyGroups = {
-	outfitName: () => string,
-	costConjunction: () => string,
-	scheduleList: () => string,
+	outfitName: string,
+	costConjunction: string,
+	scheduleList: string,
 };
 type BareReplyGroups = {
-	scheduleList: () => string,
+	scheduleList: string,
 };
 type NoSlotReplyGroups = {
-	outfitName: () => string,
+	outfitName: string,
 };
 type TokensCostGroups = {
-	tokens: () => string,
+	tokens: string,
 };
 type CoinsCostGroups = {
-	coins: () => string,
+	coins: string,
 };
 type NoCostGroups = {};
 type ScheduleGroups = {
-	dayDateTime: () => string,
+	dayDateTime: string,
 };
 type BareScheduleGroups = {
-	dayDateTime: () => string,
-	outfitNameConjunction: () => string,
+	dayDateTime: string,
+	outfitNameConjunction: string,
 };
 type OutfitDependency = {
 	help: HelpGroups,

--- a/src/dependencies/patch.d.ts
+++ b/src/dependencies/patch.d.ts
@@ -1,5 +1,5 @@
 type HelpGroups = {
-	commandMention: () => string,
+	commandMention: string,
 };
 type ReplyGroups = {};
 type NoContentOrAttachmentReplyGroups = {};

--- a/src/dependencies/raw.d.ts
+++ b/src/dependencies/raw.d.ts
@@ -1,13 +1,13 @@
 type HelpGroups = {
-	commandMention: () => string,
-	typeOptionDescription: () => string,
-	identifierOptionDescription: () => string,
+	commandMention: string,
+	typeOptionDescription: string,
+	identifierOptionDescription: string,
 };
 type NoTypeReplyGroups = {
-	typeConjunction: () => string,
+	typeConjunction: string,
 };
 type NoIdentifierReplyGroups = {
-	max: () => string,
+	max: string,
 };
 type RawDependency = {
 	help: HelpGroups,

--- a/src/dependencies/record.d.ts
+++ b/src/dependencies/record.d.ts
@@ -1,5 +1,5 @@
 type HelpWithChannelGroups = {
-	channelMention: () => string,
+	channelMention: string,
 };
 type HelpWithoutChannelGroups = {};
 type RecordDependency = {

--- a/src/dependencies/refusal.d.ts
+++ b/src/dependencies/refusal.d.ts
@@ -1,5 +1,5 @@
 type HelpWithChannelGroups = {
-	channelMention: () => string,
+	channelMention: string,
 };
 type HelpWithoutChannelGroups = {};
 type RefusalDependency = {

--- a/src/dependencies/refuse.d.ts
+++ b/src/dependencies/refuse.d.ts
@@ -1,5 +1,5 @@
 type HelpGroups = {
-	commandMention: () => string,
+	commandMention: string,
 };
 type ReplyGroups = {};
 type NoMemberReplyGroups = {};

--- a/src/dependencies/roadmap.d.ts
+++ b/src/dependencies/roadmap.d.ts
@@ -1,12 +1,12 @@
 type HelpGroups = {
-	commandMention: () => string,
+	commandMention: string,
 };
 type ReplyGroups = {
-	intent: () => string,
-	link: () => string,
+	intent: string,
+	link: string,
 };
 type IntentWithChannelGroups = {
-	channelMention: () => string,
+	channelMention: string,
 };
 type IntentWithoutChannelGroups = {};
 type RoadmapDependency = {

--- a/src/dependencies/rule7.d.ts
+++ b/src/dependencies/rule7.d.ts
@@ -1,5 +1,5 @@
 type HelpWithChannelsGroups = {
-	channelMentions: () => string,
+	channelMentions: string,
 };
 type HelpWithoutChannelsGroups = {};
 type Rule7Dependency = {

--- a/src/dependencies/soundtrack.d.ts
+++ b/src/dependencies/soundtrack.d.ts
@@ -1,16 +1,16 @@
 type HelpGroups = {
-	commandMention: () => string,
+	commandMention: string,
 };
 type ReplyGroups = {
-	linkList: () => string,
+	linkList: string,
 };
 type DefaultReplyGroups = {
-	link: () => string,
+	link: string,
 };
 type LinkGroups = {
-	title: () => string,
-	link: () => string,
-	views: () => string,
+	title: string,
+	link: string,
+	views: string,
 };
 type SoundtrackDependency = {
 	help: HelpGroups,

--- a/src/dependencies/store.d.ts
+++ b/src/dependencies/store.d.ts
@@ -1,12 +1,12 @@
 type HelpGroups = {
-	commandMention: () => string,
+	commandMention: string,
 };
 type ReplyGroups = {
-	linkList: () => string,
+	linkList: string,
 };
 type LinkGroups = {
-	title: () => string,
-	link: () => string,
+	title: string,
+	link: string,
 };
 type StoreDependency = {
 	help: HelpGroups,

--- a/src/dependencies/tracker.d.ts
+++ b/src/dependencies/tracker.d.ts
@@ -1,17 +1,17 @@
 type HelpGroups = {
-	commandMention: () => string,
+	commandMention: string,
 };
 type ReplyGroups = {
-	intent: () => string,
-	linkList: () => string,
+	intent: string,
+	linkList: string,
 };
 type IntentWithChannelGroups = {
-	channelMention: () => string,
+	channelMention: string,
 };
 type IntentWithoutChannelGroups = {};
 type LinkGroups = {
-	title: () => string,
-	link: () => string,
+	title: string,
+	link: string,
 };
 type TrackerDependency = {
 	help: HelpGroups,

--- a/src/dependencies/trailer.d.ts
+++ b/src/dependencies/trailer.d.ts
@@ -1,16 +1,16 @@
 type HelpGroups = {
-	commandMention: () => string,
+	commandMention: string,
 };
 type ReplyGroups = {
-	linkList: () => string,
+	linkList: string,
 };
 type DefaultReplyGroups = {
-	link: () => string,
+	link: string,
 };
 type LinkGroups = {
-	title: () => string,
-	link: () => string,
-	views: () => string,
+	title: string,
+	link: string,
+	views: string,
 };
 type TrailerDependency = {
 	help: HelpGroups,

--- a/src/dependencies/update.d.ts
+++ b/src/dependencies/update.d.ts
@@ -1,17 +1,17 @@
 type HelpGroups = {
-	commandMention: () => string,
+	commandMention: string,
 };
 type ReplyGroups = {
-	linkList: () => string,
+	linkList: string,
 };
 type DefaultReplyGroups = {
-	linkList: () => string,
+	linkList: string,
 };
 type LinkGroups = {
-	title: () => string,
-	link: () => string,
-	version: () => string,
-	date: () => string,
+	title: string,
+	link: string,
+	version: string,
+	date: string,
 };
 type UpdateDependency = {
 	help: HelpGroups,

--- a/src/dependencies/verification.d.ts
+++ b/src/dependencies/verification.d.ts
@@ -1,5 +1,5 @@
 type HelpWithChannelGroups = {
-	channelMention: () => string,
+	channelMention: string,
 };
 type HelpWithoutChannelGroups = {};
 type VerificationDependency = {

--- a/src/dependencies/verify.d.ts
+++ b/src/dependencies/verify.d.ts
@@ -1,8 +1,8 @@
 type HelpGroups = {
-	commandMention: () => string,
+	commandMention: string,
 };
 type ReplyGroups = {
-	name: () => string,
+	name: string,
 };
 type NoPermissionReplyGroups = {};
 type VerifyDependency = {

--- a/src/hooks/application.ts
+++ b/src/hooks/application.ts
@@ -120,9 +120,7 @@ const applicationHook: Hook = {
 		const {channel}: Webhook = webhook;
 		return channel != null ? composeAll<HelpWithChannelGroups, {}>(helpWithChannelLocalizations, localize<HelpWithChannelGroups>((): HelpWithChannelGroups => {
 			return {
-				channelMention: (): string => {
-					return `<#${channel.id}>`;
-				},
+				channelMention: `<#${channel.id}>`,
 			};
 		})) : helpWithoutChannelLocalizations;
 	},

--- a/src/hooks/approval.ts
+++ b/src/hooks/approval.ts
@@ -130,9 +130,7 @@ const approvalHook: Hook = {
 		const {channel}: Webhook = webhook;
 		return channel != null ? composeAll<HelpWithChannelGroups, {}>(helpWithChannelLocalizations, localize<HelpWithChannelGroups>((): HelpWithChannelGroups => {
 			return {
-				channelMention: (): string => {
-					return `<#${channel.id}>`;
-				},
+				channelMention: `<#${channel.id}>`,
 			};
 		})) : helpWithoutChannelLocalizations;
 	},

--- a/src/hooks/arrival.ts
+++ b/src/hooks/arrival.ts
@@ -68,9 +68,7 @@ const arrivalHook: Hook = {
 		const {guild}: GuildMember = member;
 		const {memberCount}: Guild = guild;
 		const greeting: string = greetings[Math.random() * greetings.length | 0]({
-			memberMention: (): string => {
-				return `<@${member.id}>`;
-			},
+			memberMention: `<@${member.id}>`,
 		});
 		const counting: string = memberCount % 10 !== 0 ? "" : `\nWe are now ${escapeMarkdown(cardinalFormat.format(memberCount))} members!`;
 		const {client, webhooks}: WebjobInvocation = invocation;
@@ -97,9 +95,7 @@ const arrivalHook: Hook = {
 		const {channel}: Webhook = webhook;
 		return channel != null ? composeAll<HelpWithChannelGroups, {}>(helpWithChannelLocalizations, localize<HelpWithChannelGroups>((): HelpWithChannelGroups => {
 			return {
-				channelMention: (): string => {
-					return `<#${channel.id}>`;
-				},
+				channelMention: `<#${channel.id}>`,
 			};
 		})) : helpWithoutChannelLocalizations;
 	},

--- a/src/hooks/departure.ts
+++ b/src/hooks/departure.ts
@@ -63,9 +63,7 @@ const departureHook: Hook = {
 		}
 		const [member]: ClientEvents["guildMemberRemove"] = (invocation.event as WebjobEvent<"guildMemberRemove">).data;
 		const greeting: string = greetings[Math.random() * greetings.length | 0]({
-			memberMention: (): string => {
-				return `**${escapeMarkdown(member.user.username)}**${member.user.discriminator != null && member.user.discriminator !== "0" ? `#**${escapeMarkdown(member.user.discriminator)}**` : ""}${member.user.globalName != null ? ` (**${escapeMarkdown(member.user.globalName)}**)` : ""}`;
-			},
+			memberMention: `**${escapeMarkdown(member.user.username)}**${member.user.discriminator != null && member.user.discriminator !== "0" ? `#**${escapeMarkdown(member.user.discriminator)}**` : ""}${member.user.globalName != null ? ` (**${escapeMarkdown(member.user.globalName)}**)` : ""}`,
 		});
 		const {client, webhooks}: WebjobInvocation = invocation;
 		const {user}: Client<true> = client;
@@ -91,9 +89,7 @@ const departureHook: Hook = {
 		const {channel}: Webhook = webhook;
 		return channel != null ? composeAll<HelpWithChannelGroups, {}>(helpWithChannelLocalizations, localize<HelpWithChannelGroups>((): HelpWithChannelGroups => {
 			return {
-				channelMention: (): string => {
-					return `<#${channel.id}>`;
-				},
+				channelMention: `<#${channel.id}>`,
 			};
 		})) : helpWithoutChannelLocalizations;
 	},

--- a/src/hooks/record.ts
+++ b/src/hooks/record.ts
@@ -227,9 +227,7 @@ const recordHook: Hook = {
 		const {channel}: Webhook = webhook;
 		return channel != null ? composeAll<HelpWithChannelGroups, {}>(helpWithChannelLocalizations, localize<HelpWithChannelGroups>((): HelpWithChannelGroups => {
 			return {
-				channelMention: (): string => {
-					return `<#${channel.id}>`;
-				},
+				channelMention: `<#${channel.id}>`,
 			};
 		})) : helpWithoutChannelLocalizations;
 	},

--- a/src/hooks/refusal.ts
+++ b/src/hooks/refusal.ts
@@ -130,9 +130,7 @@ const refusalHook: Hook = {
 		const {channel}: Webhook = webhook;
 		return channel != null ? composeAll<HelpWithChannelGroups, {}>(helpWithChannelLocalizations, localize<HelpWithChannelGroups>((): HelpWithChannelGroups => {
 			return {
-				channelMention: (): string => {
-					return `<#${channel.id}>`;
-				},
+				channelMention: `<#${channel.id}>`,
 			};
 		})) : helpWithoutChannelLocalizations;
 	},

--- a/src/hooks/verification.ts
+++ b/src/hooks/verification.ts
@@ -117,9 +117,7 @@ const verificationHook: Hook = {
 		const {channel}: Webhook = webhook;
 		return channel != null ? composeAll<HelpWithChannelGroups, {}>(helpWithChannelLocalizations, localize<HelpWithChannelGroups>((): HelpWithChannelGroups => {
 			return {
-				channelMention: (): string => {
-					return `<#${channel.id}>`;
-				},
+				channelMention: `<#${channel.id}>`,
 			};
 		})) : helpWithoutChannelLocalizations;
 	},

--- a/src/rules/rule7.ts
+++ b/src/rules/rule7.ts
@@ -156,11 +156,9 @@ const rule7Rule: Rule = {
 				type: "conjunction",
 			});
 			return {
-				channelMentions: (): string => {
-					return conjunctionFormat.format(channels.map<string>((channel: TextChannel | NewsChannel): string => {
-						return `<#${channel.id}>`;
-					}));
-				},
+				channelMentions: conjunctionFormat.format(channels.map<string>((channel: TextChannel | NewsChannel): string => {
+					return `<#${channel.id}>`;
+				})),
 			};
 		})) : helpWithoutChannelsLocalizations;
 	},

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -105,24 +105,24 @@ function map<K extends string, T, U>(input: {[k in K]: T}, callback: (value: T, 
 		];
 	})) as {[k in K]: U});
 }
-export function compile<Groups extends {[k in string]: () => string}>(template: string): (groups: Groups) => string {
+export function compile<Groups extends {[k in string]: string}>(template: string): (groups: Groups) => string {
 	return (groups: Groups): string => {
 		return template.replaceAll(groupsPattern, ($0: string, $1: string): string => {
-			return groups[$1]() ?? $0;
+			return groups[$1] ?? $0;
 		});
 	};
 }
-export function compileAll<Groups extends {[k in string]: () => string}>(templates: Localized<string>): Localized<(groups: Groups) => string> {
+export function compileAll<Groups extends {[k in string]: string}>(templates: Localized<string>): Localized<(groups: Groups) => string> {
 	return map<Locale, string, (groups: Groups) => string>(templates, (template: string): (groups: Groups) => string => {
 		return compile<Groups>(template);
 	});
 }
-export function compose<InputGroups extends {[k in string]: () => string}, OutputGroups extends {[k in string]: () => string}>(template: (groups: InputGroups & OutputGroups) => string, inputGroups: InputGroups): (outputGroups: OutputGroups) => string {
+export function compose<InputGroups extends {[k in string]: string}, OutputGroups extends {[k in string]: string}>(template: (groups: InputGroups & OutputGroups) => string, inputGroups: InputGroups): (outputGroups: OutputGroups) => string {
 	return (outputGroups: OutputGroups): string => {
 		return template({...outputGroups, ...inputGroups});
 	};
 }
-export function composeAll<InputGroups extends {[k in string]: () => string}, OutputGroups extends {[k in string]: () => string}>(templates: Localized<(groups: InputGroups & OutputGroups) => string>, inputGroups: Localized<InputGroups>): Localized<(outputGroups: OutputGroups) => string> {
+export function composeAll<InputGroups extends {[k in string]: string}, OutputGroups extends {[k in string]: string}>(templates: Localized<(groups: InputGroups & OutputGroups) => string>, inputGroups: Localized<InputGroups>): Localized<(outputGroups: OutputGroups) => string> {
 	return map<Locale, (groups: InputGroups & OutputGroups) => string, (groups: OutputGroups) => string>(templates, (template: (groups: InputGroups & OutputGroups) => string, locale: Locale): (groups: OutputGroups) => string => {
 		return compose<InputGroups, OutputGroups>(template, inputGroups[locale]);
 	});


### PR DESCRIPTION
There is little value to eval them lazily.
This only used to prevent groups from being computed if they did not appear in templates, which should not happen in practice. This was also very verbose.